### PR TITLE
Switched from the old ~"str" syntax to using .to_owned()

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -605,9 +605,12 @@ mod test {
 
     #[test]
     fn strs() {
-        eq(~"", vec!());
-        eq(~"A", vec!(~""));
-        eq(~"ABC", vec!(~"", ~"AB", ~"BC", ~"AC"));
+        eq("".to_owned(), vec!());
+        eq("A".to_owned(), vec!("".to_owned()));
+        eq("ABC".to_owned(), vec!("".to_owned(),
+                                 "AB".to_owned(),
+                                 "BC".to_owned(),
+                                 "AC".to_owned()));
     }
 
     // All this jazz is for testing set equality on the results of a shrinker.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ mod tester {
         /// When a test is discarded, `quickcheck` will replace it with a
         /// fresh one (up to a certain limit).
         pub fn discard() -> TestResult {
-            TestResult { status: Discard, arguments: vec!(), err: ~"", }
+            TestResult { status: Discard, arguments: vec!(), err: "".to_owned(), }
         }
 
         /// Converts a `bool` to a `TestResult`. A `true` value indicates that
@@ -169,7 +169,7 @@ mod tester {
             TestResult {
                 status: if b { Pass } else { Fail },
                 arguments: vec!(),
-                err: ~"",
+                err: "".to_owned(),
             }
         }
 
@@ -387,7 +387,7 @@ mod tester {
             let mut reader = ChanReader::new(recv);
 
             let mut t = TaskBuilder::new();
-            t.opts.name = Some((~"safefn").into_maybe_owned());
+            t.opts.name = Some(("safefn".to_owned()).into_maybe_owned());
             t.opts.stdout = Some(~stdout as ~Writer:Send);
             t.opts.stderr = Some(~stderr as ~Writer:Send);
 


### PR DESCRIPTION
The `~"string"` syntax was removed, so this replaces all instances of it with `.to_owned()`.
