### PR TITLE
Added a convenience single_shrinker function for easier shrinking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ extern crate collections;
 #[phase(syntax, link)] extern crate log;
 extern crate rand;
 
-pub use arbitrary::{Arbitrary, Gen, StdGen, Shrinker, gen, empty_shrinker};
+pub use arbitrary::{Arbitrary, Gen, StdGen, Shrinker, gen, empty_shrinker, single_shrinker};
 pub use tester::{Testable, TestResult, Config};
 pub use tester::{quickcheck, quickcheck_config, quicktest, quicktest_config};
 pub use tester::{DEFAULT_CONFIG, DEFAULT_SIZE};


### PR DESCRIPTION
A lot of the shrinking code uses `vec!()` and `.move_iter()`, which end up being not very
readable or efficient (they use an extra allocation). This adds a function similar to
`empty_shrinker` that allows you to easily create a shrinker with a single possible shrink,
which (in my opinion) is a lot cleaner.
