### PR TITLE
update string conversions

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -254,7 +254,7 @@ impl<A: Arbitrary> Arbitrary for Vec<A> {
 impl Arbitrary for String {
     fn arbitrary<G: Gen>(g: &mut G) -> String {
         let size = { let s = g.size(); g.gen_range(0, s) };
-        g.gen_ascii_str(size).to_strbuf()
+        g.gen_ascii_str(size)
     }
 
     fn shrink(&self) -> Box<Shrinker<String>> {
@@ -647,12 +647,12 @@ mod test {
 
     #[test]
     fn strs() {
-        eq("".to_owned(), vec!());
-        eq("A".to_owned(), vec!("".to_owned()));
-        eq("ABC".to_owned(), vec!("".to_owned(),
-                                 "AB".to_owned(),
-                                 "BC".to_owned(),
-                                 "AC".to_owned()));
+        eq("".to_string(), vec!());
+        eq("A".to_string(), vec!("".to_string()));
+        eq("ABC".to_string(), vec!("".to_string(),
+                                 "AB".to_string(),
+                                 "BC".to_string(),
+                                 "AC".to_string()));
     }
 
     // All this jazz is for testing set equality on the results of a shrinker.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ mod tester {
         /// error.
         pub fn error(msg: &str) -> TestResult {
             let mut r = TestResult::from_bool(false);
-            r.err = msg.to_owned();
+            r.err = msg.to_string();
             r
         }
 
@@ -158,7 +158,7 @@ mod tester {
         /// When a test is discarded, `quickcheck` will replace it with a
         /// fresh one (up to a certain limit).
         pub fn discard() -> TestResult {
-            TestResult { status: Discard, arguments: vec!(), err: "".to_owned(), }
+            TestResult { status: Discard, arguments: vec!(), err: "".to_string(), }
         }
 
         /// Converts a `bool` to a `TestResult`. A `true` value indicates that
@@ -168,7 +168,7 @@ mod tester {
             TestResult {
                 status: if b { Pass } else { Fail },
                 arguments: vec!(),
-                err: "".to_owned(),
+                err: "".to_string(),
             }
         }
 
@@ -396,7 +396,7 @@ mod tester {
             let mut reader = ChanReader::new(recv);
 
             let mut t = TaskBuilder::new();
-            t.opts.name = Some(("safefn".to_owned()).into_maybe_owned());
+            t.opts.name = Some(("safefn".to_string()).into_maybe_owned());
             t.opts.stdout = Some(box stdout as Box<Writer:Send>);
             t.opts.stderr = Some(box stderr as Box<Writer:Send>);
 
@@ -404,7 +404,7 @@ mod tester {
                 Ok(v) => Ok(v),
                 Err(_) => {
                     let s = reader.read_to_str().unwrap();
-                    Err(s.as_slice().trim().into_strbuf())
+                    Err(s.as_slice().trim().to_string())
                 }
             }
         }


### PR DESCRIPTION
With these changes `make test` passes without any compiler warnings against `rustc 0.11.0-pre-nightly (a183829 2014-05-28 01:06:45 -0700)`.
