### PR TITLE
Update Cargo.toml to the new `plugin = true` flag

### DIFF
--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Andrew Gallant <jamslam@gmail.com>"]
 [[lib]]
 name = "quickcheck_macros"
 path = "src/lib.rs"
-crate_type = ["dylib"]
+plugin = true


### PR DESCRIPTION
This flag properly communicates that the crate is a plugin which implies that it needs to be built for the host architecture and that it needs to be built as a dynamic library.
