### PR TITLE
fix Travis CI and Cargo builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
-language: c
-install:
+env:
+  global:
+    # Setting this means rustc links properly
+    - LD_LIBRARY_PATH: /usr/local/lib
+before_install:
+  # Downloading the nightly and installing manually works better than the PPA
+  # for now.
   - curl -O http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
   - tar xfz rust-nightly-x86_64-unknown-linux-gnu.tar.gz
   - (cd rust-nightly-x86_64-unknown-linux-gnu/ && sudo ./install.sh)
+  # Cargo PPAs work great!
+  - sudo add-apt-repository --yes ppa:cmrx64/cargo
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -qq cargo
 script:
+  # Test the cargo build
+  - cargo build
+  # make test needs make
   - make
   - make test
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Andrew Gallant <jamslam@gmail.com>"]
 [[lib]]
 name = "quickcheck"
 path = "src/lib.rs"
+
+[dependencies.quickcheck_macros]
+path = "quickcheck_macros/"


### PR DESCRIPTION
This sets the `LD_LIBRARY_PATH` properly upon build.

Cargo dependency added for QuickCheck Macros, so Cargo testing _almost_ works, except that the `extern crate quickcheck` magic isn't handled properly.

I can get rid of that bit if you'd prefer, but I figured you'd appreciate the Travis update.
