### PR TITLE
Wrong feature gate in the macro example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To use the `#[quickcheck]` attribute, you must enable the `phase` feature and
 import the `quickcheck_macros` crate as a syntax extension:
 
 ```rust
-#![feature(plugin)]
+#![feature(phase)]
 #[phase(plugin)]
 extern crate quickcheck_macros;
 extern crate quickcheck;


### PR DESCRIPTION
The example using the macro try to use #![feature(plugin)] but this feature gate doesn't exist. The correct one is #![feature(phase)].
