### PR TITLE
Fix: enums are now namespaced

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -6,6 +6,7 @@ use std::rand;
 use std::task::TaskBuilder;
 use super::{Arbitrary, Gen, Shrinker, StdGen};
 use tester::trap::safe;
+use tester::Status::{Discard, Fail, Pass};
 
 /// The main QuickCheck type for setting configuration and running QuickCheck.
 pub struct QuickCheck<G> {


### PR DESCRIPTION
See rust-lang/rust#18973
