### PR TITLE
Restructure implementation of Arbitrary for tuples

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -174,7 +174,7 @@ impl<A: Arbitrary, B: Arbitrary> Arbitrary for Result<A, B> {
 macro_rules! impl_arb_for_tuple(
     (($var_a:ident, $type_a:ident) $(, ($var_n:ident, $type_n:ident))*) => (
         impl<$type_a: Arbitrary, $($type_n: Arbitrary),*> Arbitrary for ($type_a, $($type_n),*) {
-            fn arbitrary<G: Gen>(g: &mut G) -> ($type_a, $($type_n),*) {
+            fn arbitrary<GEN: Gen>(g: &mut GEN) -> ($type_a, $($type_n),*) {
                 (
                     Arbitrary::arbitrary(g),
                     $({
@@ -206,7 +206,20 @@ impl_arb_for_tuple!((a, A))
 impl_arb_for_tuple!((a, A), (b, B))
 impl_arb_for_tuple!((a, A), (b, B), (c, C))
 impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D))
-
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E))
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E), (f, F))
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E), (f, F),
+                    (g, G))
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E), (f, F),
+                    (g, G), (h, H))
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E), (f, F),
+                    (g, G), (h, H), (i, I))
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E), (f, F),
+                    (g, G), (h, H), (i, I), (j, J))
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E), (f, F),
+                    (g, G), (h, H), (i, I), (j, J), (k, K))
+impl_arb_for_tuple!((a, A), (b, B), (c, C), (d, D), (e, E), (f, F),
+                    (g, G), (h, H), (i, I), (j, J), (k, K), (l, L))
 
 impl<A: Arbitrary> Arbitrary for Vec<A> {
     fn arbitrary<G: Gen>(g: &mut G) -> Vec<A> {


### PR DESCRIPTION
Arbitrary is implemented for n-tuples up to n=12. For completeness this also includes 1-tuples, which were missing before. This is achieved by refactoring the shrink implementations for an n-tuple to recurse to the implementation for an (n-1)-tuple. The resulting code pattern is simple enough to be generalized as a macro, which is then applied to larger tuples. It is not possible to go beyond 12-tuples, since Rust does not implement Clone for them.

Note that I have not yet added tests for tuples larger than 4-tuples, as I am not too familiar with the properties shrinking is supposed to fulfill. My solution works for 2, 3 and 4 and appears to be algorithmically equivalent, so I am fairly certain that it is correct. But in any case, I think somebody who is actually familiar with shrinking should review this and write the tests.
