### PR TITLE
fix: `TaskBuilder` -> `thread::Builder`, `TrieMap` is now out of tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ license = "Unlicense"
 [lib]
 name = "quickcheck"
 
+[dependencies.collect]
+
+git = "https://github.com/Gankro/collect-rs/"

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,4 +1,4 @@
-use std::collections::TrieMap;
+use collect::TrieMap;
 use std::mem;
 use std::num::{Int, Primitive, SignedInt, UnsignedInt, mod};
 use std::rand::Rng;
@@ -451,11 +451,11 @@ impl<A: Primitive + UnsignedInt> Iterator<A> for UnsignedShrinker<A> {
 
 #[cfg(test)]
 mod test {
+    use collect::TrieMap;
     use std::fmt::Show;
     use std::hash::Hash;
     use std::iter;
     use std::collections::HashSet;
-    use std::collections::TrieMap;
     use std::rand;
     use super::Arbitrary;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![feature(macro_rules, phase)]
 
-extern crate collections;
+extern crate collect;
 #[phase(plugin, link)] extern crate log;
 
 pub use arbitrary::{


### PR DESCRIPTION
`TrieMap` now lives in the `collect` crate, and this PR adds that crate as a dependency to continue providing `impl Arbitrary for TrieMap`.

(Some people suggested removing that `impl` to avoid adding a cargo dependency, see #44)
