### PR TITLE
fix: functions are now unique types and require casting to function pointers

### DIFF
--- a/examples/out_of_bounds.rs
+++ b/examples/out_of_bounds.rs
@@ -14,5 +14,5 @@ fn main() {
             })
         }
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(uint, uint) -> TestResult);
 }

--- a/examples/reverse.rs
+++ b/examples/reverse.rs
@@ -14,5 +14,5 @@ fn main() {
     fn equality_after_applying_twice(xs: Vec<int>) -> bool {
         xs == reverse(reverse(xs.as_slice()).as_slice())
     }
-    quickcheck(equality_after_applying_twice);
+    quickcheck(equality_after_applying_twice as fn(Vec<int>) -> bool);
 }

--- a/examples/reverse_single.rs
+++ b/examples/reverse_single.rs
@@ -17,5 +17,5 @@ fn main() {
         }
         TestResult::from_bool(xs == reverse(xs.as_slice()))
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(Vec<int>) -> TestResult);
 }

--- a/examples/sieve.rs
+++ b/examples/sieve.rs
@@ -47,5 +47,5 @@ fn prop_all_prime(n: uint) -> bool {
 }
 
 fn main() {
-    quickcheck(prop_all_prime);
+    quickcheck(prop_all_prime as fn(uint) -> bool);
 }

--- a/examples/sort.rs
+++ b/examples/sort.rs
@@ -41,7 +41,7 @@ fn main() {
     fn keeps_length(xs: Vec<int>) -> bool {
         xs.len() == sort(xs.as_slice()).len()
     }
-    quickcheck(keeps_length);
+    quickcheck(keeps_length as fn(Vec<int>) -> bool);
 
-    quickcheck(is_sorted)
+    quickcheck(is_sorted as fn(Vec<int>) -> bool)
 }

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -109,7 +109,7 @@ impl<G: Gen> QuickCheck<G> {
     ///         let revrev: Vec<_> = rev.into_iter().rev().collect();
     ///         xs == revrev
     ///     }
-    ///     QuickCheck::new().quickcheck(revrev);
+    ///     QuickCheck::new().quickcheck(revrev as fn(Vec<uint>) -> bool);
     /// }
     /// ```
     pub fn quickcheck<A>(&mut self, f: A) where A: Testable {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ fn prop_oob() {
         let zero: Vec<bool> = vec![];
         zero[0]
     }
-    match QuickCheck::new().quicktest(prop) {
+    match QuickCheck::new().quicktest(prop as fn() -> bool) {
         Ok(n) => panic!("prop_oob should fail with a runtime error \
                         but instead it passed {} tests.", n),
         _ => return,
@@ -23,7 +23,7 @@ fn prop_reverse_reverse() {
         let revrev: Vec<_> = rev.into_iter().rev().collect();
         xs == revrev
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(Vec<uint>) -> bool);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn reverse_single() {
             xs == xs.clone().into_iter().rev().collect::<Vec<_>>()
         )
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(Vec<uint>) -> TestResult);
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn reverse_app() {
 
         app_rev == rev_app
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(Vec<uint>, Vec<uint>) -> bool);
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn max() {
             return TestResult::from_bool(::std::cmp::max(x, y) == y)
         }
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(int, int) -> TestResult);
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn sort() {
         }
         true
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(Vec<int>) -> bool);
 }
 
 #[test]
@@ -125,5 +125,5 @@ fn sieve_of_eratosthenes() {
         }
         true
     }
-    quickcheck(prop);
+    quickcheck(prop as fn(uint) -> bool);
 }


### PR DESCRIPTION
See rust-lang/rust#19891

---

To test locally I have used this fork of `collect-rs` (Gankro/collect-rs#39), since the original one is still broken with today's nightly.

The macro source code could probably use better naming...
