### PR TITLE
update to rust nightly

### DIFF
--- a/examples/out_of_bounds.rs
+++ b/examples/out_of_bounds.rs
@@ -4,7 +4,7 @@ use std::iter::range;
 use quickcheck::{TestResult, quickcheck};
 
 fn main() {
-    fn prop(length: uint, index: uint) -> TestResult {
+    fn prop(length: usize, index: usize) -> TestResult {
         let v: Vec<_> = range(0, length).collect();
 
         if index < length {
@@ -15,5 +15,5 @@ fn main() {
             })
         }
     }
-    quickcheck(prop as fn(uint, uint) -> TestResult);
+    quickcheck(prop as fn(usize, usize) -> TestResult);
 }

--- a/examples/reverse.rs
+++ b/examples/reverse.rs
@@ -11,8 +11,8 @@ fn reverse<T: Clone>(xs: &[T]) -> Vec<T> {
 }
 
 fn main() {
-    fn equality_after_applying_twice(xs: Vec<int>) -> bool {
+    fn equality_after_applying_twice(xs: Vec<isize>) -> bool {
         xs == reverse(reverse(xs.as_slice()).as_slice())
     }
-    quickcheck(equality_after_applying_twice as fn(Vec<int>) -> bool);
+    quickcheck(equality_after_applying_twice as fn(Vec<isize>) -> bool);
 }

--- a/examples/reverse_single.rs
+++ b/examples/reverse_single.rs
@@ -11,11 +11,11 @@ fn reverse<T: Clone>(xs: &[T]) -> Vec<T> {
 }
 
 fn main() {
-    fn prop(xs: Vec<int>) -> TestResult {
+    fn prop(xs: Vec<isize>) -> TestResult {
         if xs.len() != 1 {
             return TestResult::discard()
         }
         TestResult::from_bool(xs == reverse(xs.as_slice()))
     }
-    quickcheck(prop as fn(Vec<int>) -> TestResult);
+    quickcheck(prop as fn(Vec<isize>) -> TestResult);
 }

--- a/examples/sieve.rs
+++ b/examples/sieve.rs
@@ -5,7 +5,7 @@ use std::num::Float;
 
 use quickcheck::quickcheck;
 
-fn sieve(n: uint) -> Vec<uint> {
+fn sieve(n: usize) -> Vec<usize> {
     if n <= 1 {
         return vec!()
     }
@@ -26,14 +26,14 @@ fn sieve(n: uint) -> Vec<uint> {
     primes
 }
 
-fn is_prime(n: uint) -> bool {
+fn is_prime(n: usize) -> bool {
     if n == 0 || n == 1 {
         return false
     } else if n == 2 {
         return true
     }
 
-    let max_possible = (n as f64).sqrt().ceil() as uint;
+    let max_possible = (n as f64).sqrt().ceil() as usize;
     for i in iter::range_inclusive(2, max_possible) {
         if n % i == 0 {
             return false
@@ -42,11 +42,11 @@ fn is_prime(n: uint) -> bool {
     return true
 }
 
-fn prop_all_prime(n: uint) -> bool {
+fn prop_all_prime(n: usize) -> bool {
     let primes = sieve(n);
     primes.iter().all(|&i| is_prime(i))
 }
 
 fn main() {
-    quickcheck(prop_all_prime as fn(uint) -> bool);
+    quickcheck(prop_all_prime as fn(usize) -> bool);
 }

--- a/examples/sort.rs
+++ b/examples/sort.rs
@@ -29,7 +29,7 @@ fn sort<T: Clone + Ord>(list: &[T]) -> Vec<T> {
 }
 
 fn main() {
-    fn is_sorted(xs: Vec<int>) -> bool {
+    fn is_sorted(xs: Vec<isize>) -> bool {
         for win in xs.as_slice().windows(2) {
             if win[0] > win[1] {
                 return false
@@ -38,10 +38,10 @@ fn main() {
         true
     }
 
-    fn keeps_length(xs: Vec<int>) -> bool {
+    fn keeps_length(xs: Vec<isize>) -> bool {
         xs.len() == sort(xs.as_slice()).len()
     }
-    quickcheck(keeps_length as fn(Vec<int>) -> bool);
+    quickcheck(keeps_length as fn(Vec<isize>) -> bool);
 
-    quickcheck(is_sorted as fn(Vec<int>) -> bool)
+    quickcheck(is_sorted as fn(Vec<isize>) -> bool)
 }

--- a/quickcheck_macros/examples/attribute.rs
+++ b/quickcheck_macros/examples/attribute.rs
@@ -15,7 +15,7 @@ fn reverse<T: Clone>(xs: &[T]) -> Vec<T> {
 }
 
 #[quickcheck]
-fn double_reversal_is_identity(xs: Vec<int>) -> bool {
+fn double_reversal_is_identity(xs: Vec<isize>) -> bool {
     xs == reverse(reverse(xs.as_slice()).as_slice())
 }
 

--- a/quickcheck_macros/src/lib.rs
+++ b/quickcheck_macros/src/lib.rs
@@ -6,6 +6,8 @@
 #![doc(html_root_url = "http://burntsushi.net/rustdoc/quickcheck")]
 
 #![feature(plugin_registrar)]
+// TODO(burntsushi) audit use of unstable
+#![allow(unstable)]
 
 extern crate syntax;
 extern crate rustc;
@@ -25,7 +27,7 @@ use rustc::plugin::Registry;
 #[doc(hidden)]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(token::intern("quickcheck"),
-                                  Modifier(box expand_meta_quickcheck));
+                                  Modifier(Box::new(expand_meta_quickcheck)));
 }
 
 /// Expands the `#[quickcheck]` attribute.
@@ -33,7 +35,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 /// Expands:
 /// ```
 /// #[quickcheck]
-/// fn check_something(_: uint) -> bool {
+/// fn check_something(_: usize) -> bool {
 ///     true
 /// }
 /// ```
@@ -41,10 +43,10 @@ pub fn plugin_registrar(reg: &mut Registry) {
 /// ```
 /// #[test]
 /// fn check_something() {
-///     fn check_something(_: uint) -> bool {
+///     fn check_something(_: usize) -> bool {
 ///         true
 ///     }
-///     ::quickcheck::quickcheck(check_something as fn(uint) -> bool)
+///     ::quickcheck::quickcheck(check_something as fn(usize) -> bool)
 /// }
 /// ```
 fn expand_meta_quickcheck(cx: &mut ExtCtxt,

--- a/quickcheck_macros/tests/macro.rs
+++ b/quickcheck_macros/tests/macro.rs
@@ -9,7 +9,7 @@ extern crate quickcheck;
 use quickcheck::TestResult;
 
 #[quickcheck]
-fn min(x: int, y: int) -> TestResult {
+fn min(x: isize, y: isize) -> TestResult {
     if x < y {
         TestResult::discard()
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@
 #![doc(html_root_url = "http://burntsushi.net/rustdoc/quickcheck")]
 #![experimental]
 
+// TODO(burntsushi) audit use of unstable and int/uint
+#![feature(int_uint)]
+#![allow(unstable)]
+
 #[cfg(feature = "collect")]
 extern crate collect;
 #[macro_use] extern crate log;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,17 +18,17 @@ fn prop_oob() {
 
 #[test]
 fn prop_reverse_reverse() {
-    fn prop(xs: Vec<uint>) -> bool {
+    fn prop(xs: Vec<usize>) -> bool {
         let rev: Vec<_> = xs.clone().into_iter().rev().collect();
         let revrev: Vec<_> = rev.into_iter().rev().collect();
         xs == revrev
     }
-    quickcheck(prop as fn(Vec<uint>) -> bool);
+    quickcheck(prop as fn(Vec<usize>) -> bool);
 }
 
 #[test]
 fn reverse_single() {
-    fn prop(xs: Vec<uint>) -> TestResult {
+    fn prop(xs: Vec<usize>) -> TestResult {
         if xs.len() != 1 {
             return TestResult::discard()
         }
@@ -36,40 +36,40 @@ fn reverse_single() {
             xs == xs.clone().into_iter().rev().collect::<Vec<_>>()
         )
     }
-    quickcheck(prop as fn(Vec<uint>) -> TestResult);
+    quickcheck(prop as fn(Vec<usize>) -> TestResult);
 }
 
 #[test]
 fn reverse_app() {
-    fn prop(xs: Vec<uint>, ys: Vec<uint>) -> bool {
+    fn prop(xs: Vec<usize>, ys: Vec<usize>) -> bool {
         let mut app = xs.clone();
         app.push_all(ys.as_slice());
-        let app_rev: Vec<uint> = app.into_iter().rev().collect();
+        let app_rev: Vec<usize> = app.into_iter().rev().collect();
 
-        let rxs: Vec<uint> = xs.into_iter().rev().collect();
-        let mut rev_app = ys.into_iter().rev().collect::<Vec<uint>>();
+        let rxs: Vec<usize> = xs.into_iter().rev().collect();
+        let mut rev_app = ys.into_iter().rev().collect::<Vec<usize>>();
         rev_app.extend(rxs.into_iter());
 
         app_rev == rev_app
     }
-    quickcheck(prop as fn(Vec<uint>, Vec<uint>) -> bool);
+    quickcheck(prop as fn(Vec<usize>, Vec<usize>) -> bool);
 }
 
 #[test]
 fn max() {
-    fn prop(x: int, y: int) -> TestResult {
+    fn prop(x: isize, y: isize) -> TestResult {
         if x > y {
             return TestResult::discard()
         } else {
             return TestResult::from_bool(::std::cmp::max(x, y) == y)
         }
     }
-    quickcheck(prop as fn(int, int) -> TestResult);
+    quickcheck(prop as fn(isize, isize) -> TestResult);
 }
 
 #[test]
 fn sort() {
-    fn prop(mut xs: Vec<int>) -> bool {
+    fn prop(mut xs: Vec<isize>) -> bool {
         xs.sort_by(|x, y| x.cmp(y));
         let upto = if xs.len() == 0 { 0 } else { xs.len()-1 };
         for i in iter::range(0, upto) {
@@ -79,13 +79,13 @@ fn sort() {
         }
         true
     }
-    quickcheck(prop as fn(Vec<int>) -> bool);
+    quickcheck(prop as fn(Vec<isize>) -> bool);
 }
 
 #[test]
 #[should_fail]
 fn sieve_of_eratosthenes() {
-    fn sieve(n: uint) -> Vec<uint> {
+    fn sieve(n: usize) -> Vec<usize> {
         if n <= 1 {
             return vec![];
         }
@@ -106,18 +106,18 @@ fn sieve_of_eratosthenes() {
         primes
     }
 
-    fn prop(n: uint) -> bool {
+    fn prop(n: usize) -> bool {
         let primes = sieve(n);
         primes.iter().all(|&i| is_prime(i))
     }
-    fn is_prime(n: uint) -> bool {
+    fn is_prime(n: usize) -> bool {
         if n == 0 || n == 1 {
             return false;
         } else if n == 2 {
             return true;
         }
 
-        let max_possible = (n as f64).sqrt().ceil() as uint;
+        let max_possible = (n as f64).sqrt().ceil() as usize;
         for i in iter::range_inclusive(2, max_possible) {
             if n % i == 0 {
                 return false;
@@ -125,5 +125,5 @@ fn sieve_of_eratosthenes() {
         }
         true
     }
-    quickcheck(prop as fn(uint) -> bool);
+    quickcheck(prop as fn(usize) -> bool);
 }


### PR DESCRIPTION
- uint/int -> usize/isize
- `box foo` -> `Box::new(foo)`
- `hash` module and `String/Show` fallout
- added `#[allow(unstable)]` and `#[feature(int_uint)]` to avoid a flood of warnings (but you may want to audit their use in a follow up commit)