### PR TITLE
Fix Rust nightly compile error by relying on closure type inference instead of type annotation

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -387,7 +387,7 @@ fn shuffle_vec<A: Clone>(xs: &[A], k: usize) -> Vec<Vec<A>> {
             return vec![vec![]];
         }
 
-        let cat = |&mut: x: &Vec<A>| {
+        let cat = |x: &Vec<A>| {
             let mut pre = xs1.clone();
             pre.extend(x.clone().into_iter());
             pre


### PR DESCRIPTION
Fixes the following compile error with latest Rust nightly:

```
~/src/rust-quickcheck[master] $ rustc --version
rustc 1.0.0-nightly (706be5ba1 2015-02-05 23:14:28 +0000)

~/src/rust-quickcheck[(0.1.37)] $ cargo test
   Compiling quickcheck v0.1.37 (file:///home/caspar/src/rust-quickcheck)
src/arbitrary.rs:390:20: 390:27 error: obsolete syntax: `:`, `&mut:`, or `&:` syntax
src/arbitrary.rs:390         let cat = |&mut: x: &Vec<A>| {
                                        ^~~~~~~
note: rely on inference instead
src/arbitrary.rs:390:20: 390:27 error: obsolete syntax: `:`, `&mut:`, or `&:` syntax
src/arbitrary.rs:390         let cat = |&mut: x: &Vec<A>| {
                                        ^~~~~~~
note: rely on inference instead
error: aborting due to previous error
error: aborting due to previous error
Build failed, waiting for other jobs to finish...
Could not compile `quickcheck`.
```
