### PR TITLE
update to Rust master

### DIFF
--- a/examples/out_of_bounds.rs
+++ b/examples/out_of_bounds.rs
@@ -1,13 +1,10 @@
-#![feature(core)]
-
 extern crate quickcheck;
 
-use std::iter::range;
 use quickcheck::{TestResult, quickcheck};
 
 fn main() {
     fn prop(length: usize, index: usize) -> TestResult {
-        let v: Vec<_> = range(0, length).collect();
+        let v: Vec<_> = (0..length).collect();
         if index < length {
             TestResult::discard()
         } else {

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 use std::collections::hash_map::HashMap;
 use std::hash::Hash;
 use std::mem;
-use std::num::{self, Int, SignedInt, UnsignedInt};
+use std::num::{self, Int, SignedInt};
 
 #[cfg(feature = "collect_impls")]
 use collect::TrieMap;
@@ -421,7 +421,7 @@ struct UnsignedShrinker<A> {
     i: A,
 }
 
-impl<A: UnsignedInt + Send + 'static> UnsignedShrinker<A> {
+impl<A: Int + Send + 'static> UnsignedShrinker<A> {
     fn new(x: A) -> Box<Iterator<Item=A>+'static> {
         if x == Int::zero() {
             empty_shrinker::<A>()
@@ -436,7 +436,7 @@ impl<A: UnsignedInt + Send + 'static> UnsignedShrinker<A> {
     }
 }
 
-impl<A: UnsignedInt> Iterator for UnsignedShrinker<A> {
+impl<A: Int> Iterator for UnsignedShrinker<A> {
     type Item = A;
     fn next(&mut self) -> Option<A> {
         if self.x - self.i < self.x {


### PR DESCRIPTION
I didn't replace the uses of the deprecated `range_step` because that function's misuse is the point of the tests that use it. However, as it will be removed eventually, we should find a better example.