### PR TITLE
Implement Testable for more generic results

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -245,11 +245,11 @@ impl Testable for TestResult {
     fn result<G: Gen>(&self, _: &mut G) -> TestResult { self.clone() }
 }
 
-impl<A> Testable for Result<A, String> where A: Testable {
+impl<A, E> Testable for Result<A, E> where A: Testable, E: Debug + Send + 'static {
     fn result<G: Gen>(&self, g: &mut G) -> TestResult {
         match *self {
             Ok(ref r) => r.result(g),
-            Err(ref err) => TestResult::error(&**err),
+            Err(ref err) => TestResult::error(format!("{:?}", err)),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -121,3 +121,15 @@ fn sieve_not_all_primes() {
     }
     quickcheck(prop_prime_iff_in_the_sieve as fn(usize) -> bool);
 }
+
+#[test]
+fn testable_result() {
+    fn result() -> Result<bool, String> { Ok(true) }
+    quickcheck(result as fn() -> Result<bool, String>);
+}
+
+#[test]
+#[should_panic]
+fn testable_result_err() {
+    quickcheck(Err::<bool, i32> as fn(i32) -> Result<bool, i32>);
+}


### PR DESCRIPTION
It is sufficient to constrain the error type to be `Debug + Send + 'static` instead of limiting it to `String` only.