### PR TITLE
Use `env_logger` to support `RUST_LOG` again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ license = "Unlicense/MIT"
 name = "quickcheck"
 
 [dependencies]
+env_logger = "0.3"
 log = "0.3"
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![allow(deprecated)] // for connect -> join in 1.3
 
+extern crate env_logger;
 #[macro_use] extern crate log;
 extern crate rand;
 

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -108,6 +108,9 @@ impl<G: Gen> QuickCheck<G> {
     /// }
     /// ```
     pub fn quickcheck<A>(&mut self, f: A) where A: Testable {
+        // Ignore log init failures, implying it has already been done.
+        let _ = ::env_logger::init();
+
         match self.quicktest(f) {
             Ok(ntests) => info!("(Passed {} QuickCheck tests.)", ntests),
             Err(result) => panic!(result.failed_msg()),


### PR DESCRIPTION
Debug macros are only used in one place, so logger initialization can simply happen there.

Fixes #95.