### PR TITLE
Add support for std::time::{Duration, SystemTime}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 keywords = ["testing", "quickcheck", "property", "shrinking", "fuzz"]
 license = "Unlicense/MIT"
 
+[features]
+unstable = []
+
 [lib]
 name = "quickcheck"
 

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -11,6 +11,7 @@ use std::collections::{
 use std::hash::Hash;
 use std::iter::{empty, once};
 use std::ops::{Range, RangeFrom, RangeTo, RangeFull};
+use std::time::Duration;
 use entropy_pool::EntropyPool;
 use shrink::{Shrinker, StdShrinker};
 
@@ -640,6 +641,33 @@ impl<T: Arbitrary + Clone + PartialOrd> Arbitrary for RangeTo<T> {
 
 impl Arbitrary for RangeFull {
     fn arbitrary<G: Gen>(_: &mut G) -> RangeFull { .. }
+}
+
+impl Arbitrary for Duration {
+    fn arbitrary<G: Gen>(gen: &mut G) -> Self {
+        let seconds = u64::arbitrary(gen);
+        let nanoseconds = u32::arbitrary(gen) % 1_000_000;
+        Duration::new(seconds, nanoseconds)
+    }
+}
+
+
+#[cfg(feature = "unstable")]
+mod unstable_impls {
+    use {Arbitrary, Gen};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    impl Arbitrary for SystemTime {
+        fn arbitrary<G: Gen>(gen: &mut G) -> Self {
+            let after_epoch = bool::arbitrary(gen);
+            let duration = Duration::arbitrary(gen);
+            if after_epoch {
+                UNIX_EPOCH + duration
+            } else {
+                UNIX_EPOCH - duration
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! [README](https://github.com/BurntSushi/quickcheck).
 
 #![allow(deprecated)] // for connect -> join in 1.3
+#![cfg_attr(feature = "unstable", feature(time2))]
 
 extern crate env_logger;
 #[macro_use] extern crate log;


### PR DESCRIPTION
Arbitrary SystemTime can only be generated when built with `--features
unstable`. It doesn't seem like new arbitrary implementaions normally
get tested, so I've not added any tests for these. I also can't think of
any particularly important values for `shrink` here, as no durations or
times are particularly more likely to cause bugs than others.

We're moduloing the number of nanoseconds for a duration to always be
subsecond, so we don't get any isses when seconds is generated to
`u64::MAX_VAL`, or close to it.

Fixes #109.