### PR TITLE
Fix showing the message after panic from panic!() or assert!()

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -414,9 +414,14 @@ fn safe<T, F>(fun: F) -> Result<T, String>
         where F: FnOnce() -> T, F: Send + 'static, T: Send + 'static {
     let t = ::std::thread::Builder::new().name("safe".into());
     t.spawn(fun).unwrap().join().map_err(|any_err| {
-        match any_err.downcast_ref::<&Debug>() {
-            Some(ref s) => format!("{:?}", s),
-            None => "UNABLE TO SHOW RESULT OF PANIC.".into(),
+        // Extract common types of panic payload:
+        // panic and assert produce &str or String
+        if let Some(&s) = any_err.downcast_ref::<&str>() {
+            s.to_owned()
+        } else if let Some(s) = any_err.downcast_ref::<String>() {
+            s.to_owned()
+        } else {
+            "UNABLE TO SHOW RESULT OF PANIC.".to_owned()
         }
     })
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -162,3 +162,33 @@ fn regression_issue_83_signed() {
         .gen(StdGen::new(rand::thread_rng(), 1024))
         .quickcheck(prop as fn(i8) -> bool)
 }
+
+// Test that we can show the message after panic
+#[test]
+#[should_panic(expected = "foo")]
+fn panic_msg_1() {
+    fn prop() -> bool {
+        panic!("foo");
+    }
+    quickcheck(prop as fn() -> bool);
+}
+
+#[test]
+#[should_panic(expected = "foo")]
+fn panic_msg_2() {
+    fn prop() -> bool {
+        assert!("foo" == "bar");
+        true
+    }
+    quickcheck(prop as fn() -> bool);
+}
+
+#[test]
+#[should_panic(expected = "foo")]
+fn panic_msg_3() {
+    fn prop() -> bool {
+        assert_eq!("foo", "bar");
+        true
+    }
+    quickcheck(prop as fn() -> bool);
+}


### PR DESCRIPTION
Fix showing the message after panic from panic!() or assert!()

Typical panics produce either &str or String (depending if formatting is
used or not), so we use a simple type switch to handle these two after
a panic in a test case.

Fixes #91