### PR TITLE
Add Restriction to filter Arbitrary values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,14 @@
 //! [README](https://github.com/BurntSushi/quickcheck).
 
 #![allow(deprecated)] // for connect -> join in 1.3
-#![cfg_attr(feature = "unstable", feature(time2))]
+#![cfg_attr(feature = "unstable", feature(core_intrinsics, time2))]
 
 extern crate env_logger;
 #[macro_use] extern crate log;
 extern crate rand;
 
 pub use arbitrary::{
-    Arbitrary, Gen, StdGen,
+    Arbitrary, Gen, StdGen, RAnd, ROr, Restricted, Restriction,
     empty_shrinker, single_shrinker,
 };
 pub use rand::Rng;


### PR DESCRIPTION
> Sometimes you want something arbitrary, but not too arbitrary. When you're encoding the something you want using the type signature of a #[quickcheck] test function, this is an easy way to skip values that you don't actually want without having to do a whole new Arbitrary implementation for the constraint.

Not complete yet since it lacks docs, but I'd like to know if this seems like a good approach at least.
