### PR TITLE
time2 has been stabilized

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -700,7 +700,7 @@ mod unstable_impls {
         }
 
         fn shrink(&self) -> Box<Iterator<Item=Self>> {
-            let duration = match self.duration_from_earlier(UNIX_EPOCH) {
+            let duration = match self.duration_since(UNIX_EPOCH) {
                 Ok(duration) => duration,
                 Err(e) => e.duration(),
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //! [README](https://github.com/BurntSushi/quickcheck).
 
 #![allow(deprecated)] // for connect -> join in 1.3
-#![cfg_attr(feature = "unstable", feature(time2))]
 
 extern crate env_logger;
 #[macro_use] extern crate log;


### PR DESCRIPTION
`duration_from_earlier` was renamed to `duration_since`, and the time2
feature is no longer needed. This can be removed from the unstable
feature gate once 1.8 is released, but these changes are required to
compile on beta and nightly.