### PR TITLE
Port over the shrinking behavior from before f017c01.

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -335,3 +335,18 @@ fn safe<T, F>(fun: F) -> Result<T, String>
 /// Convenient aliases.
 trait AShow : Arbitrary + Debug {}
 impl<A: Arbitrary + Debug> AShow for A {}
+
+#[cfg(test)]
+mod test {
+    use {QuickCheck, StdGen, quickcheck};
+    use super::TestResult;
+    #[test]
+    fn shrinking_regression_issue_126() {
+        fn thetest(vals: Vec<bool>) -> bool {
+            vals.iter().filter(|&v| *v).count() < 2
+        }
+        let failing_case = QuickCheck::new().quicktest(thetest as fn(vals: Vec<bool>) -> bool).unwrap_err();
+        let expected_argument = format!("{:?}", [true, true]);
+        assert_eq!(failing_case.arguments, vec![expected_argument]);
+    }
+}


### PR DESCRIPTION
Re: tickets #126 and #127.

This ensures that we try to recursively shrink a failing case, in order to find the smallest instance. Repeating myself, this means that the test case:

```rust
#[cfg(test)]
mod test {
    use quickcheck::quickcheck;
    #[test]
    fn testy_test() {
        use quickcheck::Arbitrary;
        fn thetest(vals: Vec<bool>) -> bool {
            vals.iter().filter(|&v| *v).count() < 2
        }
        quickcheck(thetest as fn(vals: Vec<bool>) -> bool)
    }
```

Will fail with `[quickcheck] TEST FAILED. Arguments: ([true, true])`, rather than something like `[quickcheck] TEST FAILED. Arguments: ([false, false, false, true, true, true, false, true, true, ...])`. This was mostly just adapting the logic used previously to the new macro.

I'd welcome any feedback on how you think it might be improved.

Thanks,