### PR TITLE
Add crate feature "use_logging" that's enabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ license = "Unlicense/MIT"
 
 [features]
 unstable = []
+use_logging = ["log", "env_logger"]
+default = ["use_logging"]
 
 [lib]
 name = "quickcheck"
 
 [dependencies]
-env_logger = "0.3"
-log = "0.3"
+env_logger = { version = "0.3", optional = true }
+log = { version = "0.3", optional = true }
 rand = "0.3"

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ N.B. When using `quickcheck` (either directly or via the attributes),
 (like the number of tests passed). This is **not** needed to show
 witnesses for failures.
 
+Crate features:
+
+- `"unstable"`: Enables Arbitrary implementations that require the Rust nightly
+  channel.
+- `"use_logging"`: (Enabled by default.) Enables the log messages governed
+  `RUST_LOG`.
+
 
 ### Discarding test results (or, properties are polymorphic!)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@
 
 #![allow(deprecated)] // for connect -> join in 1.3
 
+#[cfg(feature = "use_logging")]
 extern crate env_logger;
+#[cfg(feature = "use_logging")]
 #[macro_use] extern crate log;
 extern crate rand;
 
@@ -63,6 +65,19 @@ macro_rules! quickcheck {
         }
     )
 }
+
+#[cfg(feature = "use_logging")]
+fn env_logger_init() -> Result<(), log::SetLoggerError> {
+    env_logger::init()
+}
+
+#[cfg(not(feature = "use_logging"))]
+fn env_logger_init() { }
+#[cfg(not(feature = "use_logging"))]
+macro_rules! info {
+    ($($_ignore:tt)*) => { () };
+}
+
 
 mod arbitrary;
 mod tester;

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -111,10 +111,10 @@ impl<G: Gen> QuickCheck<G> {
     /// ```
     pub fn quickcheck<A>(&mut self, f: A) where A: Testable {
         // Ignore log init failures, implying it has already been done.
-        let _ = ::env_logger::init();
+        let _ = ::env_logger_init();
 
         match self.quicktest(f) {
-            Ok(ntests) => info!("(Passed {} QuickCheck tests.)", ntests),
+            Ok(_ntests) => info!("(Passed {} QuickCheck tests.)", _ntests),
             Err(result) => panic!(result.failed_msg()),
         }
     }


### PR DESCRIPTION
This is to allow a faster compile of quickcheck. Logging brings a lot of dependencies that are more or less unused.

Fixes #142 