### PR TITLE
Allow QC_TESTS and QC_MAX_TESTS to set tests / max_tests

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 use std::panic;
+use std::env;
+use std::cmp;
 
 use rand;
 
@@ -13,6 +15,21 @@ pub struct QuickCheck<G> {
     gen: G,
 }
 
+fn qc_tests() -> usize {
+    match env::var("QC_TESTS") {
+        Ok(val) => val.parse().expect("QC_TESTS value could not converted to number"),
+        Err(_) => 100,
+    }
+}
+
+fn qc_max_tests() -> usize {
+    match env::var("QC_MAX_TESTS") {
+        Ok(val) => val.parse().expect("QC_MAX_TESTS value could not converted to number"),
+        Err(_) => 10000,
+    }
+}
+
+
 impl QuickCheck<StdGen<rand::ThreadRng>> {
     /// Creates a new QuickCheck value.
     ///
@@ -24,9 +41,11 @@ impl QuickCheck<StdGen<rand::ThreadRng>> {
     /// the max number of overall tests is set to `10000` and the generator
     /// is set to a `StdGen` with a default size of `100`.
     pub fn new() -> QuickCheck<StdGen<rand::ThreadRng>> {
+        let tests = qc_tests();
+        let max_tests = cmp::max(tests, qc_max_tests());
         QuickCheck {
-            tests: 100,
-            max_tests: 10000,
+            tests: tests,
+            max_tests: max_tests,
             gen: StdGen::new(rand::thread_rng(), 100),
         }
     }

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -16,19 +16,20 @@ pub struct QuickCheck<G> {
 }
 
 fn qc_tests() -> usize {
-    match env::var("QC_TESTS") {
-        Ok(val) => val.parse().expect("QC_TESTS value could not converted to number"),
-        Err(_) => 100,
+    let default = 100;
+    match env::var("QUICKCHECK_TESTS") {
+        Ok(val) => val.parse().unwrap_or(default),
+        Err(_) => default,
     }
 }
 
 fn qc_max_tests() -> usize {
-    match env::var("QC_MAX_TESTS") {
-        Ok(val) => val.parse().expect("QC_MAX_TESTS value could not converted to number"),
-        Err(_) => 10000,
+    let default = 10_000;
+    match env::var("QUICKCHECK_MAX_TESTS") {
+        Ok(val) => val.parse().unwrap_or(default),
+        Err(_) => default,
     }
 }
-
 
 impl QuickCheck<StdGen<rand::ThreadRng>> {
     /// Creates a new QuickCheck value.

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -31,6 +31,14 @@ fn qc_max_tests() -> usize {
     }
 }
 
+fn qc_gen_size() -> usize {
+    let default = 100;
+    match env::var("QUICKCHECK_GENERATOR_SIZE") {
+        Ok(val) => val.parse().unwrap_or(default),
+        Err(_) => default,
+    }
+}
+
 impl QuickCheck<StdGen<rand::ThreadRng>> {
     /// Creates a new QuickCheck value.
     ///
@@ -44,10 +52,11 @@ impl QuickCheck<StdGen<rand::ThreadRng>> {
     pub fn new() -> QuickCheck<StdGen<rand::ThreadRng>> {
         let tests = qc_tests();
         let max_tests = cmp::max(tests, qc_max_tests());
+        let gen_size = qc_gen_size();
         QuickCheck {
             tests: tests,
             max_tests: max_tests,
-            gen: StdGen::new(rand::thread_rng(), 100),
+            gen: StdGen::new(rand::thread_rng(), gen_size),
         }
     }
 }


### PR DESCRIPTION
In practice I've wanted two kinds of quickcheck runs: fast and
comprehensive. To date the comprehensive testing has been done
by manually adjusting tests / max_tests up from the defaults of
100 / 10000. This involves a recompilation step.

If quickcheck were able to read environment variables to set its
tests / max_tests that recompilation step would not be needed and
a nightly CI task could be written to do a comprehensive QC run.

This commit introduces QC_TESTS and QC_MAX_TESTS to meet the
above. In the event that QC_MAX_TESTS < QC_TESTS then the
max_tests will be set to QC_TESTS.

Signed-off-by: Brian L. Troutwine blt@postmates.com
