### PR TITLE
Added attr support to quickcheck! macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ macro_rules! quickcheck {
     (@as_items $($i:item)*) => ($($i)*);
     {
         $(
+            $(#[$m:meta])*
             fn $fn_name:ident($($arg_name:ident : $arg_ty:ty),*) -> $ret:ty {
                 $($code:tt)*
             }
@@ -55,6 +56,7 @@ macro_rules! quickcheck {
             @as_items
             $(
                 #[test]
+                $(#[$m])*
                 fn $fn_name() {
                     fn prop($($arg_name: $arg_ty),*) -> $ret {
                         $($code)*

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,6 +31,12 @@ quickcheck! {
         let revrev: Vec<_> = rev.into_iter().rev().collect();
         xs == revrev
     }
+
+    #[should_panic]
+    fn prop_macro_panic(_x: u32) -> bool {
+        assert!(false);
+        false
+    }
 }
 
 #[test]


### PR DESCRIPTION
I wanted to be able to `#[ignore]` some of my quickcheck tests defined with `quickcheck!` because they're expensive and I don't want to run them every time in dev. This (short) PR adds that ability.

I *don't* have tests for this, because I wasn't sure how to go about doing so. All existing tests pass, however.

    quickcheck! {
        #[ignore]
        fn prop(...) -> bool {
            ...
        }
    }