### PR TITLE
quickcheck_macros: Update for rust-lang/rust#37824

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
-  - if [ "$TEST_SUITE" = "suite_nightly" ]; then
+  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi

--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -21,4 +21,4 @@ path = "examples/attribute.rs"
 
 [dependencies.quickcheck]
 path = ".."
-version = "0.3"
+version = "0.4"

--- a/quickcheck_macros/src/lib.rs
+++ b/quickcheck_macros/src/lib.rs
@@ -11,12 +11,12 @@ extern crate syntax;
 extern crate rustc_plugin;
 
 use syntax::ast;
-use syntax::ast::{ItemKind, StmtKind, Stmt, TyKind};
+use syntax::ast::{Ident, ItemKind, StmtKind, Stmt, TyKind};
 use syntax::codemap;
-use syntax::parse::token;
 use syntax::ext::base::{ExtCtxt, MultiModifier, Annotatable};
 use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
+use syntax::symbol::Symbol;
 
 use rustc_plugin::Registry;
 
@@ -24,7 +24,7 @@ use rustc_plugin::Registry;
 #[plugin_registrar]
 #[doc(hidden)]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_syntax_extension(token::intern("quickcheck"),
+    reg.register_syntax_extension(Symbol::intern("quickcheck"),
                                   MultiModifier(Box::new(expand_meta_quickcheck)));
 }
 
@@ -83,7 +83,7 @@ fn wrap_item(cx: &mut ExtCtxt,
     // Copy original function without attributes
     let prop = P(ast::Item {attrs: Vec::new(), ..item.clone()});
     // ::quickcheck::quickcheck
-    let check_ident = token::str_to_ident("quickcheck");
+    let check_ident = Ident::from_str("quickcheck");
     let check_path = vec!(check_ident, check_ident);
     // Wrap original function in new outer function,
     // calling ::quickcheck::quickcheck()
@@ -104,7 +104,7 @@ fn wrap_item(cx: &mut ExtCtxt,
     let mut attrs = item.attrs.clone();
     // Add #[test] attribute
     attrs.push(cx.attribute(
-        span, cx.meta_word(span, token::intern_and_get_ident("test"))));
+        span, cx.meta_word(span, Symbol::intern("test"))));
     // Attach the attributes to the outer function
     Annotatable::Item(P(ast::Item {attrs: attrs, ..(*test).clone()}))
 }


### PR DESCRIPTION
[“Clean up `ast::Attribute`, `ast::CrateConfig`, and string interning”](https://github.com/rust-lang/rust/pull/37824)

Resolves these errors:

```
error[E0425]: unresolved name `token::intern`
  --> src/lib.rs:27:35
   |
27 |     reg.register_syntax_extension(token::intern("quickcheck"),
   |                                   ^^^^^^^^^^^^^ unresolved name

error[E0425]: unresolved name `token::str_to_ident`
  --> src/lib.rs:86:23
   |
86 |     let check_ident = token::str_to_ident("quickcheck");
   |                       ^^^^^^^^^^^^^^^^^^^ unresolved name

error[E0425]: unresolved name `token::intern_and_get_ident`
   --> src/lib.rs:107:34
    |
107 |         span, cx.meta_word(span, token::intern_and_get_ident("test"))));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unresolved name

error: aborting due to 3 previous errors
```
