### PR TITLE
Implement `Arbitrary` for `Box`

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -674,6 +674,15 @@ impl Arbitrary for Duration {
     }
 }
 
+impl<A: Arbitrary> Arbitrary for Box<A> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Box<A> {
+        Box::new(A::arbitrary(g))
+    }
+
+    fn shrink(&self) -> Box<Iterator<Item=Box<A>>> {
+        Box::new((**self).shrink().map(Box::new))
+    }
+}
 
 #[cfg(feature = "unstable")]
 mod unstable_impls {


### PR DESCRIPTION
Lots of boilerplate is required when implementing `Arbitrary` for recursive types.
Having an impl of `Arbitrary` for boxes would be quite nice when working with such structures!