### PR TITLE
Handle non-terminating shrinkers in shrink_failure

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -329,8 +329,7 @@ impl<T: Testable,
 
                     // otherwise keep going
                     best = Some(r_new);
-                    values.truncate(0);
-                    values.extend(next.shrink());
+                    values = next.shrink().collect();
                 }
             }
             // as soon as we hit a node where none of the results of next.shrink()

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -301,11 +301,10 @@ impl<T: Testable,
             self_: fn($($name),*) -> T,
             a: ($($name,)*),
         ) -> Option<TestResult> {
-            let mut values = Vec::new();
+            let mut values = a.shrink().collect::<Vec<_>>();
             let mut best = None;
             let mut depth = 1;
 
-            values.extend(a.shrink());
             while let Some(next) = values.pop() {
                 let ($($name,)*) = next.clone();
                 let mut r_new = safe(move || {self_($($name),*)}).result(g);


### PR DESCRIPTION
Rather than failing with a stack overflow, if we hit an arbitrary
depth, we report the most simplified form, and note that shrinking
does not seem to terminate.

This is a more generic alternative to #139, and should address common cases of #133.

Before this is ready to merge (assuming it's the approach you want to go with), we need to decide what a reasonable default recursion limit (maximum depth) is. Currently it's hardcoded to 1000 in an embarrassing fashion. I'm not sure what the best way of exposing it to configuration in `QuickCheck<G>` is; perhaps it should just be an additional argument to `.result()`, passed in by `quicktest<A>`?


Disclaimer: this is the first piece of Rust I've ever written, and was mostly done so that I have something to experiment with. So I might be missing something obvious, doing something really wrong, etc; you should probably review it more closely than something from an experienced rust dev. But hey, it compiled and passed tests! 