### PR TITLE
Add Arbitrary for non-default Hashers in HashMap/HashSet

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -8,7 +8,7 @@ use std::collections::{
     LinkedList,
     VecDeque,
 };
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::iter::{empty, once};
 use std::ops::{Range, RangeFrom, RangeTo, RangeFull};
 use std::time::Duration;
@@ -312,16 +312,16 @@ impl<K: Arbitrary + Ord, V: Arbitrary> Arbitrary for BTreeMap<K, V> {
     }
 }
 
-impl<K: Arbitrary + Eq + Hash, V: Arbitrary> Arbitrary for HashMap<K, V> {
-    fn arbitrary<G: Gen>(g: &mut G) -> HashMap<K, V> {
+impl<K: Arbitrary + Eq + Hash, V: Arbitrary, S: BuildHasher + Default + Clone + Send + 'static> Arbitrary for HashMap<K, V, S> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let vec: Vec<(K, V)> = Arbitrary::arbitrary(g);
         vec.into_iter().collect()
     }
 
-    fn shrink(&self) -> Box<Iterator<Item=HashMap<K, V>>> {
+    fn shrink(&self) -> Box<Iterator<Item=Self>> {
         let vec: Vec<(K, V)> = self.clone().into_iter().collect();
         Box::new(vec.shrink()
-                    .map(|v| v.into_iter().collect::<HashMap<K, V>>()))
+                    .map(|v| v.into_iter().collect::<Self>()))
     }
 }
 
@@ -350,15 +350,15 @@ impl<T: Arbitrary + Ord> Arbitrary for BinaryHeap<T> {
     }
 }
 
-impl<T: Arbitrary + Eq + Hash> Arbitrary for HashSet<T> {
-    fn arbitrary<G: Gen>(g: &mut G) -> HashSet<T> {
+impl<T: Arbitrary + Eq + Hash, S: BuildHasher + Default + Clone + Send + 'static> Arbitrary for HashSet<T, S> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let vec: Vec<T> = Arbitrary::arbitrary(g);
         vec.into_iter().collect()
     }
 
-    fn shrink(&self) -> Box<Iterator<Item=HashSet<T>>> {
+    fn shrink(&self) -> Box<Iterator<Item=Self>> {
         let vec: Vec<T> = self.clone().into_iter().collect();
-        Box::new(vec.shrink().map(|v| v.into_iter().collect::<HashSet<T>>()))
+        Box::new(vec.shrink().map(|v| v.into_iter().collect::<Self>()))
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,8 @@
 use std::cmp::Ord;
 use rand;
 use super::{QuickCheck, StdGen, TestResult, quickcheck};
+use std::collections::{HashSet, HashMap};
+use std::hash::{BuildHasherDefault, SipHasher};
 
 #[test]
 fn prop_oob() {
@@ -215,4 +217,22 @@ fn regression_issue_107_hang() {
         a.contains(&1)
     }
     quickcheck(prop as fn(_) -> bool);
+}
+
+quickcheck! {
+    fn basic_hashset(_set: HashSet<u8>) -> bool {
+        true
+    }
+
+    fn basic_hashmap(_map: HashMap<u8, u8>) -> bool {
+        true
+    }
+
+    fn substitute_hashset(_set: HashSet<u8, BuildHasherDefault<SipHasher>>) -> bool {
+        true
+    }
+
+    fn substitute_hashmap(_map: HashMap<u8, u8, BuildHasherDefault<SipHasher>>) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
The motivation for this is that I want to use a non-standard hasher (in my case, [fnv](https://doc.servo.org/fnv/)) instead of the default `SipHasher`. However, the current implementation has trait bounds that implicitly restrict the third parameter of `HashMap` (or second of `HashSet`) to the [default](https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html).

It turned out to be very simple to address this: parameterizing the `impl`'s with the hasher type parameter `S` works with both the short-hand generally used (`HashMap<K, V>` or `HashSet<K>`) and with types that have the third specified (e.g. `HashMap<K, V, BuildHasherDefault<FnvHasher>>`).

The added tests are purely compilation tests: if they compile, they pass. One set checks that the normal `HashMap<K, V>` types still work, and the other tests that adding the parameter for the `Hasher` works. I didn't want to add a new dev-dependency, so it simply uses the built-in `SipHasher`. While this is basically equivalent to the default, it does fail without modifying the implementation of `Arbitrary` for these types because `RandomState` (the default) is not a type alias for `BuildHasherDefault<SipHasher>`.