### PR TITLE
Arbitrary for PathBuf and OsString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags
 target
 build
 Cargo.lock
+*~

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@ use rand;
 use super::{QuickCheck, StdGen, TestResult, quickcheck};
 use std::collections::{HashSet, HashMap};
 use std::hash::{BuildHasherDefault, SipHasher};
+use std::path::PathBuf;
 
 #[test]
 fn prop_oob() {
@@ -220,6 +221,13 @@ fn regression_issue_107_hang() {
 }
 
 quickcheck! {
+    /// The following is a very simplistic test, which only verifies
+    /// that our PathBuf::arbitraryl does not panic.  Still, that's
+    /// something!  :)
+    fn pathbuf(_p: PathBuf) -> bool {
+        true
+    }
+
     fn basic_hashset(_set: HashSet<u8>) -> bool {
         true
     }


### PR DESCRIPTION
Hello, I just implemented hopefully a reasonable Arbitrary for PathBuf (and incidentally OsString).  The PathBuf arbitrary tries to get somewhat interesting and/or realistic paths, but doesn't try to hard (e.g. it will *extremely** rarely pick a path like foo/../bar.  But it does get realistic prefixes (hopefully), and shouldn't do anything too insane.

I also added *~ to gitignore.