### PR TITLE
#[derive(Arbitrary)]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rust:
   - beta
   - nightly
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
+  - cargo build --all --verbose
+  - cargo test --all --verbose
+  - cargo doc --all
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,7 @@ script:
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi
-  - cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml
-  - cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml
+  - if [ "$TRAVIS_RUST_VERSION" != "1.12.0" ]; then
+      cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml;
+      cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ rust:
   - beta
   - nightly
 script:
-  - cargo build --all --verbose
-  - cargo test --all --verbose
-  - cargo doc --all
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo doc
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi
+  - cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml
+  - cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[workspace]
+members = [
+	"quickcheck_derive"
+]
+
 [package]
 name = "quickcheck"
 version = "0.4.2"  #:version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
-[workspace]
-members = [
-	"quickcheck_derive"
-]
-
 [package]
 name = "quickcheck"
 version = "0.4.2"  #:version

--- a/quickcheck_derive/.gitignore
+++ b/quickcheck_derive/.gitignore
@@ -1,0 +1,3 @@
+target/
+**/*.rs.bk
+Cargo.lock

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = ["Nathaniel Ringo <remexre@gmail.com>"]
+description = "#[derive(Arbitrary, Clone)]"
+license = "MIT"
+name = "quickcheck_derive"
+version = "0.1.2"
+
+[dependencies]
+quote = "^0.3.15"
+syn = "^0.11.11"
+
+[dev-dependencies.quickcheck]
+path = ".."
+version = "0.4.2"
+
+[lib]
+proc-macro = true

--- a/quickcheck_derive/src/attrs.rs
+++ b/quickcheck_derive/src/attrs.rs
@@ -1,0 +1,37 @@
+use quote::Tokens;
+use syn::{Attribute, DeriveInput, Ident, Lit, MetaItem, NestedMetaItem};
+
+pub fn process_attrs(item: &DeriveInput) -> Tokens {
+    let mut toks = quote!(true);
+    for constraint in item.attrs.iter().flat_map(constraints) {
+        toks.append("&&");
+        toks.append("(");
+        toks.append(constraint);
+        toks.append(")");
+    }
+    toks
+}
+
+fn constraints(attr: &Attribute) -> Vec<&str> {
+    match attr.value {
+        MetaItem::List(ref name, ref nested) => if name == &Ident::new("arbitrary") {
+            nested.iter().filter_map(|n| match *n {
+                NestedMetaItem::MetaItem(ref m) => match *m {
+                    MetaItem::NameValue(ref name, ref val) => if name == &Ident::new("constraint") {
+                        match *val {
+                            Lit::Str(ref s, _) => Some(s as &str),
+                            _ => panic!("Invalid 'arbitrary' attribute"),
+                        }
+                    } else {
+                        panic!("Invalid 'arbitrary' attribute");
+                    },
+                    _ => panic!("Invalid 'arbitrary' attribute"),
+                },
+                _ => panic!("Invalid 'arbitrary' attribute"),
+            }).collect()
+        } else {
+            Vec::new()
+        },
+        _ => Vec::new(),
+    }
+}

--- a/quickcheck_derive/src/lib.rs
+++ b/quickcheck_derive/src/lib.rs
@@ -1,0 +1,53 @@
+#![crate_type = "proc-macro"]
+#![recursion_limit = "128"]
+
+extern crate proc_macro;
+#[macro_use]
+extern crate quote;
+extern crate syn;
+
+mod attrs;
+mod structural;
+
+use attrs::*;
+use proc_macro::TokenStream;
+use structural::*;
+use syn::{Body, parse_derive_input};
+
+#[proc_macro_derive(Arbitrary, attributes(arbitrary))]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let item = parse_derive_input(&input.to_string())
+        .expect("Couldn't parse item");
+    let (arbitrary, shrink) = match item.body {
+        Body::Struct(ref variant) => derive_struct(&item, &variant),
+        Body::Enum(ref variants) => derive_enum(&item, &variants),
+    };
+    let valid = process_attrs(&item);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+    let ast = quote! {
+        impl ::quickcheck::Arbitrary for #impl_generics #name #ty_generics #where_clause {
+            #[allow(unused_mut, unused_variables)]
+            fn arbitrary<G: ::quickcheck::Gen>(_g: &mut G) -> Self {
+                // TODO Find a way to use "self" instead of "this".
+                let valid = |this: &Self| { #valid };
+                let mut gen = move || { #arbitrary };
+
+                loop {
+                    let out = gen();
+                    if valid(&out) {
+                        return out;
+                    }
+                }
+            }
+
+            fn shrink(&self) -> Box<Iterator<Item=Self>> {
+                #shrink
+            }
+        }
+    };
+    ast.to_string()
+       .parse()
+       .expect("Couldn't parse string to tokens")
+}

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -1,0 +1,170 @@
+use quote::Tokens;
+use syn::{DeriveInput, Field, Ident, Variant, VariantData};
+
+pub fn derive_struct(item: &DeriveInput, variant: &VariantData) -> (Tokens, Tokens) {
+    let name = &item.ident;
+    
+    let arbitrary = arbitrary_variant(variant, name);
+    let shrink = match *variant {
+        VariantData::Struct(ref fields) => {
+            let field_names = fields.iter()
+                .map(|f| f.ident.as_ref().unwrap())
+                .collect::<Vec<_>>();
+            let field_names = &field_names;
+            let alphas = alpha_names(fields.len());
+            let alphas = &alphas;
+
+            let tuple_pattern = match alphas.len() {
+                0 => quote!(()),
+                1 => {
+                    let alpha = &alphas[0];
+                    quote!(#alpha)
+                },
+                _ => quote!((#(#alphas),*)),
+            };
+
+            quote! {
+                Box::new(
+                    (#(self.#field_names),*).shrink().map(|#tuple_pattern| #name {
+                        #(#field_names: #alphas),*
+                    })
+                )
+            }
+        },
+        VariantData::Tuple(ref fields) => {
+            let field_names = (0..fields.len()).map(Ident::new).map(|i| quote!(self.#i));
+            let alpha_names = &alpha_names(fields.len());
+
+            quote! {
+                // TODO This isn't a *great* way to do this until we get
+                // generics over tuples, to be able to implement shrinking
+                // for tuples of all sizes.
+                Box::new((#(#field_names),*).shrink().map(|(#(#alpha_names),*)| #name(#(#alpha_names),*)))
+            }
+        },
+        VariantData::Unit => quote!(quickcheck::empty_shrinker()),
+    };
+
+    (arbitrary, shrink)
+}
+
+pub fn derive_enum(item: &DeriveInput, variants: &[Variant]) -> (Tokens, Tokens) {
+    let name = &item.ident;
+    let variant_count = variants.len();
+    if variants.len() == 0 {
+        panic!("Can't derive Arbitrary on an uninhabited type!");
+    }
+
+    let arbitrary_variants = variants.iter().enumerate().map(|(i, v)| {
+        let arb = arbitrary_variant(&v.data, &v.ident);
+        quote!(#i => #name::#arb)
+    });
+    let shrink_variants = variants.iter().map(|v| enum_shrink_variant(name, v));
+
+    let arbitrary = quote! {
+        match _g.gen_range(0, #variant_count) {
+            #(#arbitrary_variants,)*
+            _ => unreachable!(),
+        }
+    };
+    let shrink = quote! {
+        match *self {
+            #(#shrink_variants,)*
+        }
+    };
+
+    (arbitrary, shrink)
+}
+fn arbitrary_variant(variant: &VariantData, name: &Ident) -> Tokens {
+    match *variant {
+        VariantData::Struct(ref fields) => {
+            let fields = fields.iter().map(derive_field);
+            
+            quote! {
+                #name {
+                    #(#fields),*
+                }
+            }
+        },
+        VariantData::Tuple(ref fields) => {
+            let arbitraries = fields.iter().map(derive_field);
+ 
+            quote! {
+                #name (#(#arbitraries),*)
+            }
+        },
+        VariantData::Unit => quote!(#name),
+    }
+}
+
+fn derive_field(field: &Field) -> Tokens {
+    let gen = quote! { ::quickcheck::Arbitrary::arbitrary(_g) };
+    if let Some(ref name) = field.ident {
+        quote! { #name: #gen }
+    } else {
+        quote! { #gen }
+    }
+}
+
+fn alpha_name(n: usize) -> Ident {
+    Ident::new(format!("quickcheck_derived_param_{}", n))
+}
+fn alpha_names(i: usize) -> Vec<Ident> {
+    (0..i).map(alpha_name).collect()
+}
+
+fn enum_shrink_variant(name: &Ident, v: &Variant) -> Tokens {
+    let ident = &v.ident;
+    match v.data {
+        VariantData::Struct(ref fields) => {
+            let field_names = fields.iter()
+                .map(|f| f.ident.as_ref().unwrap())
+                .collect::<Vec<_>>();
+            let field_names = &field_names;
+            let alphas = alpha_names(fields.len());
+            let alphas = &alphas;
+
+            let tuple_pattern = match alphas.len() {
+                0 => quote!(()),
+                1 => {
+                    let alpha = &alphas[0];
+                    quote!(#alpha)
+                },
+                _ => quote!((#(#alphas),*)),
+            };
+
+            quote! {
+                #name::#ident {
+                    #(#field_names: ref #alphas),*
+                } => {
+                    let iter = (#(#alphas.clone()),*).shrink().map(|#tuple_pattern| #name::#ident {
+                        #(#field_names: #alphas),*
+                    });
+                    Box::new(iter)
+                }
+            }
+        },
+        VariantData::Tuple(ref fields) => {
+            let l = fields.len();
+            let alphas = alpha_names(l);
+            let alphas = &alphas;
+            let tuple_pattern = match alphas.len() {
+                0 => quote!(()),
+                1 => {
+                    let alpha = &alphas[0];
+                    quote!(#alpha)
+                },
+                _ => quote!((#(#alphas),*)),
+            };
+            quote! {
+                #name::#ident(#(ref #alphas),*) => {
+                    let iter = (#(#alphas.clone()),*)
+                        .shrink()
+                        .map(|#tuple_pattern| #name::#ident(#(#alphas),*));
+                    Box::new(iter)
+                }
+            }
+        },
+        VariantData::Unit => quote!(#name::#ident => ::quickcheck::empty_shrinker()),
+    }
+}

--- a/quickcheck_derive/tests/constraints.rs
+++ b/quickcheck_derive/tests/constraints.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+#[arbitrary(constraint = "this.alpha == this.bravo.is_positive()")]
+struct TestStruct {
+    alpha: bool,
+    bravo: isize,
+}
+
+quickcheck! {
+    fn struct_constraint(t: TestStruct) -> bool {
+        t.alpha == t.bravo.is_positive()
+    }
+}

--- a/quickcheck_derive/tests/enum.rs
+++ b/quickcheck_derive/tests/enum.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+enum Xyzzy {
+    Alpha,
+    Bravo(char),
+    Charlie(Vec<char>, Vec<u8>),
+    Delta(Option<char>),
+    Echo(()),
+    Foxtrot {
+        one: bool,
+        two: (),
+        three: isize,
+    },
+    Golf {},
+    Hotel {
+        foo: usize,
+    },
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_xyzzy(_xyzzy: Xyzzy) -> bool {
+        true
+    }
+}

--- a/quickcheck_derive/tests/rect.rs
+++ b/quickcheck_derive/tests/rect.rs
@@ -1,0 +1,39 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+#[arbitrary(constraint = "this.left.checked_add(this.width).is_some()")]
+#[arbitrary(constraint = "this.top.checked_add(this.height).is_some()")]
+pub struct Rect {
+    left: u8,
+    top: u8,
+    width: u8,
+    height: u8,
+}
+
+impl Rect {
+    /// Returns the area of the rectangle, or None if it overflows a u8.
+    pub fn area(&self) -> Option<u8> {
+        self.width.checked_mul(self.height)
+    }
+}
+
+quickcheck! {
+    fn zero_area_iff_zero_dim(r: Rect) -> bool {
+        (r.area() == Some(0)) == (r.height == 0 || r.width == 0)
+    }
+}
+
+quickcheck! {
+    fn first_constraint_holds(r: Rect) -> bool {
+        r.left.checked_add(r.width).is_some()
+    }
+}
+
+quickcheck! {
+    fn second_constraint_holds(r: Rect) -> bool {
+        r.top.checked_add(r.height).is_some()
+    }
+}

--- a/quickcheck_derive/tests/struct.rs
+++ b/quickcheck_derive/tests/struct.rs
@@ -1,0 +1,43 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Foo {
+    alpha: i32,
+    bravo: isize,
+}
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Bar(bool, u32, char);
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Baz();
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Quux;
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_foo(_foo: Foo) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_bar(_bar: Bar) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_baz(_baz: Baz) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_quux(_quux: Quux) -> bool {
+        true
+    }
+}

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -75,6 +75,10 @@ pub fn single_shrinker<A: 'static>(value: A) -> Box<Iterator<Item=A>> {
 /// Aside from shrinking, `Arbitrary` is different from the `std::Rand` trait
 /// in that it uses a `Gen` to control the distribution of random values.
 ///
+/// This trait can be derived with the `quickcheck_derive` crate. In that case,
+/// constraints can be added via attributes, and the `valid` function will be
+/// generated based on them.
+///
 /// As of now, all types that implement `Arbitrary` must also implement
 /// `Clone`. (I'm not sure if this is a permanent restriction.)
 ///


### PR DESCRIPTION
### Summary:
Implements a stable-friendly `#[derive(Arbitrary)]`, with support for generation, shrinking, and constraints. Example:

```rust
#[macro_use]
extern crate quickcheck;
#[macro_use]
extern crate quickcheck_derive;

#[derive(Arbitrary, Clone, Debug)]
#[arbitrary(constraint = "this.alpha == this.bravo.is_positive()")]
struct TestStruct {
    alpha: bool,
    bravo: isize,
}

quickcheck! {
    fn struct_constraint(t: TestStruct) -> bool {
        t.alpha == t.bravo.is_positive()
    }
}
```

### Known Issues:
 - More tests would probably be a good thing; the existing tests essentially just ensure the derive outputs code that compiles.
 - Struct shrinking is implementing by transforming a struct into a tuple, shrinking the tuple, and mapping it back to the struct. 9-tuples and larger cannot be shrunk (see #146), so structs with more than 8 members cannot either.
 - Constraints have to use `this` instead of `self`. Constraints get turned into a function defined inside the `arbitrary` method, where no `self` exists. They therefore cannot use `self` (at least, to my knowledge).