### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ quickcheck(prop as fn(Vec<isize>) -> TestResult);
 So now our property returns a `TestResult`, which allows us to encode a bit
 more information. There are a few more
 [convenience functions defined for the `TestResult`
-type](http://burntsushi.net/rustdoc/quickcheck/struct.TestResult.html).
+type](http://docs.rs/quickcheck/0.5.0/quickcheck/struct.TestResult.html).
 For example, we can't just return a `bool`, so we convert a `bool` value to a
 `TestResult`.
 


### PR DESCRIPTION
I noticed this link was broken while reading through the docs.

I'm not completely happy with the doc link I added because it is pinned to a specific version rather than the latest version, which I think would make more sense for a reference from the head of master. Do you happen to know if there is a know good way to deal with this problem? If not it might be worth asking the docs.rs maintainers to add the ability to name the latest version with a URI.