### PR TITLE
Implement Arbitrary for 128-bit integers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ license = "Unlicense/MIT"
 unstable = []
 use_logging = ["log", "env_logger"]
 default = ["use_logging"]
+i128 = ["rand/i128_support"]
 
 [lib]
 name = "quickcheck"

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ witnesses for failures.
 
 Crate features:
 
+- `"i128"`: Enables Arbitrary implementations for 128-bit integers.
 - `"unstable"`: Enables Arbitrary implementations that require the Rust nightly
   channel.
 - `"use_logging"`: (Enabled by default.) Enables the log messages governed

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -710,6 +710,10 @@ macro_rules! unsigned_arbitrary {
 unsigned_arbitrary! {
     usize, u8, u16, u32, u64
 }
+#[cfg(feature = "i128")]
+unsigned_arbitrary! {
+    u128
+}
 
 macro_rules! signed_shrinker {
     ($ty:ty) => {
@@ -778,6 +782,10 @@ macro_rules! signed_arbitrary {
 
 signed_arbitrary! {
     isize, i8, i16, i32, i64
+}
+#[cfg(feature = "i128")]
+signed_arbitrary! {
+    i128
 }
 
 impl Arbitrary for f32 {
@@ -1031,6 +1039,14 @@ mod test {
         eq(0i64, vec![]);
     }
 
+    #[cfg(feature="i128")]
+    #[test]
+    fn ints128() {
+        eq(5i128, vec![0, 3, 4]);
+        eq(-5i128, vec![5, 0, -3, -4]);
+        eq(0i128, vec![]);
+    }
+
     #[test]
     fn uints() {
         eq(5usize, vec![0, 3, 4]);
@@ -1061,6 +1077,12 @@ mod test {
         eq(0u64, vec![]);
     }
 
+    #[cfg(feature = "i128")]
+    #[test]
+    fn uints128() {
+        eq(5u128, vec![0, 3, 4]);
+        eq(0u128, vec![]);
+    }
 
     macro_rules! define_float_eq {
         ($ty:ty) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![allow(deprecated)] // for connect -> join in 1.3
 
+#![cfg_attr(feature = "i128", feature(i128_type, i128))]
+
 #[cfg(feature = "use_logging")]
 extern crate env_logger;
 #[cfg(feature = "use_logging")]


### PR DESCRIPTION
Now that rust-lang-nursery/rand#163 is merged we can do this.

Closes #162.