### PR TITLE
Document and expose qc_gen_size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck"
-version = "0.5.0"  #:version
+version = "0.5.1"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Automatic property based testing with shrinking."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use arbitrary::{
     empty_shrinker, single_shrinker,
 };
 pub use rand::Rng;
-pub use tester::{QuickCheck, Testable, TestResult, quickcheck};
+pub use tester::{QuickCheck, Testable, TestResult, quickcheck, qc_gen_size};
 
 /// A macro for writing quickcheck tests.
 ///

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -32,7 +32,13 @@ fn qc_max_tests() -> u64 {
     }
 }
 
-fn qc_gen_size() -> usize {
+/// The default size of the generator used by:
+/// `QuickCheck::<StdGen<rand::ThreadRng>>::new()`.
+///
+/// You can customize this by setting the environment variable
+/// `QUICKCHECK_GENERATOR_SIZE` to a value that can be parsed
+/// as a `usize`.
+pub fn qc_gen_size() -> usize {
     let default = 100;
     match env::var("QUICKCHECK_GENERATOR_SIZE") {
         Ok(val) => val.parse().unwrap_or(default),


### PR DESCRIPTION
# In this PR

+ Expose and document `qc_gen_size`
+ Bump version to `5.0.1`.

# Motivation

So that I can provide interoperability with quickcheck for proptest as seen [`here`](https://github.com/Centril/proptest-quickcheck-interop/blob/master/src/lib.rs#L149-L159) without copying the function.

PS: see https://github.com/AltSysrq/proptest/issues/18 for main discussion of the interoperability layer - it will either get added to proptest itself or to a separate crate.