### PR TITLE
Upgrade to env_logger 0.5 and log 0.4; don't enable regex.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ i128 = ["rand/i128_support"]
 name = "quickcheck"
 
 [dependencies]
-env_logger = { version = "0.4", optional = true }
-log = { version = "0.3", optional = true }
+env_logger = { version = "0.5", default-features = false, optional = true }
+log = { version = "0.4", optional = true }
 rand = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ macro_rules! quickcheck {
 
 #[cfg(feature = "use_logging")]
 fn env_logger_init() -> Result<(), log::SetLoggerError> {
-    env_logger::init()
+    env_logger::try_init()
 }
 
 #[cfg(not(feature = "use_logging"))]


### PR DESCRIPTION
Upgrade to env_logger 0.5 and log 0.4 to reduce the need for
projects already using env_logger 0.5 and/or log 0.4 to compile
those libraries multiple times.

Don't enable the regex feature of env_logger by default, to avoid
forcing a regex dependency on dependent projects. A project can
enable the regex feature by adding a dependency on env_logger
without `default-features = false`.

Signed-off-by: Brian Smith <brian@briansmith.org>