### PR TITLE
Update rand crate to 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.20.0
+  - 1.21.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.21.0
+  - 1.22.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ name = "quickcheck"
 [dependencies]
 env_logger = { version = "0.5", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
-rand = "0.4"
+rand = "0.5"

--- a/benches/tuples.rs
+++ b/benches/tuples.rs
@@ -14,7 +14,7 @@ macro_rules! bench_shrink {
             #[bench]
             fn $fn_name(b: &mut Bencher) {
                 // Use a deterministic generator to benchmark on the same data
-                let mut gen = StdGen::new(IsaacRng::new_unseeded(), 100);
+                let mut gen = StdGen::new(IsaacRng::new_from_u64(0), 100);
                 let value: $type = Arbitrary::arbitrary(&mut gen);
 
                 b.iter(|| {

--- a/benches/tuples.rs
+++ b/benches/tuples.rs
@@ -5,7 +5,8 @@ extern crate rand;
 extern crate test;
 
 use quickcheck::{Arbitrary, StdGen};
-use rand::isaac::IsaacRng;
+use rand::prng::hc128::Hc128Rng;
+use rand::SeedableRng;
 use test::Bencher;
 
 macro_rules! bench_shrink {
@@ -14,7 +15,7 @@ macro_rules! bench_shrink {
             #[bench]
             fn $fn_name(b: &mut Bencher) {
                 // Use a deterministic generator to benchmark on the same data
-                let mut gen = StdGen::new(IsaacRng::new_from_u64(0), 100);
+                let mut gen = StdGen::new(Hc128Rng::from_seed([0u8; 32]), 100);
                 let value: $type = Arbitrary::arbitrary(&mut gen);
 
                 b.iter(|| {

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -19,14 +19,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rand::Rng;
+use rand::{self, Rng, RngCore};
 
-/// `Gen` wraps a `rand::Rng` with parameters to control the distribution of
+/// `Gen` wraps a `rand::RngCore` with parameters to control the distribution of
 /// random values.
 ///
 /// A value with type satisfying the `Gen` trait can be constructed with the
 /// `gen` function in this crate.
-pub trait Gen : Rng {
+pub trait Gen : RngCore {
     fn size(&self) -> usize;
 }
 
@@ -45,22 +45,25 @@ pub struct StdGen<R> {
 /// The `size` parameter controls the size of random values generated.
 /// For example, it specifies the maximum length of a randomly generated vector
 /// and also will specify the maximum magnitude of a randomly generated number.
-impl<R: Rng> StdGen<R> {
+impl<R: RngCore> StdGen<R> {
     pub fn new(rng: R, size: usize) -> StdGen<R> {
         StdGen { rng: rng, size: size }
     }
 }
 
-impl<R: Rng> Rng for StdGen<R> {
+impl<R: RngCore> RngCore for StdGen<R> {
     fn next_u32(&mut self) -> u32 { self.rng.next_u32() }
 
     // some RNGs implement these more efficiently than the default, so
     // we might as well defer to them.
     fn next_u64(&mut self) -> u64 { self.rng.next_u64() }
     fn fill_bytes(&mut self, dest: &mut [u8]) { self.rng.fill_bytes(dest) }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.rng.try_fill_bytes(dest)
+    }
 }
 
-impl<R: Rng> Gen for StdGen<R> {
+impl<R: RngCore> Gen for StdGen<R> {
     fn size(&self) -> usize { self.size }
 }
 


### PR DESCRIPTION
This PR updates `rand` crate to version 0.5.

Minimum Rust version (in .travis.yml) pushed to 1.22.0.
