### PR TITLE
Re-export all of `rand`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate env_logger;
 #[cfg(feature = "use_logging")]
 #[macro_use] extern crate log;
-extern crate rand;
+pub extern crate rand;
 
 pub use arbitrary::{
     Arbitrary, Gen, StdGen,


### PR DESCRIPTION
Users of `quickcheck` need to use the same version of rand that quickcheck does if they want to make full use of rand's API, esp when implementing `Arbitrary`. This allows them to use `quickcheck::rand`, and still use another version of `rand` for other purposes if they wish.