### PR TITLE
Fix failing build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the input space quickly. (It should be the same strategy used in
 [Koen Claessen's QuickCheck for
 Haskell](http://hackage.haskell.org/package/QuickCheck).)
 
-[![Build status](https://api.travis-ci.org/BurntSushi/quickcheck.svg)](https://travis-ci.org/BurntSushi/quickcheck)
+[![Build status](https://travis-ci.org/BurntSushi/quickcheck.svg?branch=master)](https://travis-ci.org/BurntSushi/quickcheck)
 [![](http://meritbadge.herokuapp.com/quickcheck)](https://crates.io/crates/quickcheck)
 
 Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).


### PR DESCRIPTION
Changes the build badge to point to the latest build result of master. Currently it will show the latest completed build status, regardless of branch.

URL recommended by Travis, as show [here](https://i.imgur.com/KnIKbNJ.png).