### PR TITLE
macros: switch to using `proc-macro`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+  - if [ "$TRAVIS_RUST_VERSION" != "1.22.0" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.22.0
+  - 1.24.1
   - stable
   - beta
   - nightly
@@ -8,7 +8,7 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
-  - if [ "$TRAVIS_RUST_VERSION" != "1.22.0" ]; then
+  - if [ "$TRAVIS_RUST_VERSION" != "1.24.1" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi

--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -14,8 +14,12 @@ autotests = false
 [lib]
 name = "quickcheck_macros"
 path = "src/lib.rs"
-plugin = true
+proc-macro = true
 
-[dependencies.quickcheck]
-path = ".."
-version = "0.7.1"
+[dependencies]
+proc-macro2 = "0.4.19"
+quote = "0.6.8"
+syn = { version = "0.15", features = ["full"] }
+
+[dev-dependencies]
+quickcheck = { path = "..", version = "0.7.2" }

--- a/quickcheck_macros/examples/attribute.rs
+++ b/quickcheck_macros/examples/attribute.rs
@@ -1,9 +1,9 @@
-#![feature(custom_attribute)]
-#![feature(plugin)]
 #![allow(dead_code)]
-#![plugin(quickcheck_macros)]
 
 extern crate quickcheck;
+extern crate quickcheck_macros;
+
+use quickcheck_macros::quickcheck;
 
 fn reverse<T: Clone>(xs: &[T]) -> Vec<T> {
     let mut rev = vec!();

--- a/quickcheck_macros/tests/macro.rs
+++ b/quickcheck_macros/tests/macro.rs
@@ -1,11 +1,10 @@
-#![feature(plugin)]
-
 #![allow(non_upper_case_globals)]
-#![plugin(quickcheck_macros)]
 
 extern crate quickcheck;
+extern crate quickcheck_macros;
 
 use quickcheck::TestResult;
+use quickcheck_macros::quickcheck;
 
 #[quickcheck]
 fn min(x: isize, y: isize) -> TestResult {


### PR DESCRIPTION
This makes `quickcheck_macros` usable on stable since Rust 1.30, but is a breaking change.