### PR TITLE
Expand the ranges of arbitrary integers.

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -129,19 +129,21 @@ fn is_prime(n: usize) -> bool {
 #[test]
 #[should_panic]
 fn sieve_not_prime() {
-    fn prop_all_prime(n: usize) -> bool {
-        sieve(n).into_iter().all(is_prime)
+    fn prop_all_prime(n: u8) -> bool {
+        sieve(n as usize).into_iter().all(is_prime)
     }
-    quickcheck(prop_all_prime as fn(usize) -> bool);
+    quickcheck(prop_all_prime as fn(u8) -> bool);
 }
 
 #[test]
 #[should_panic]
 fn sieve_not_all_primes() {
-    fn prop_prime_iff_in_the_sieve(n: usize) -> bool {
-        sieve(n) == (0..(n + 1)).filter(|&i| is_prime(i)).collect::<Vec<_>>()
+    fn prop_prime_iff_in_the_sieve(n: u8) -> bool {
+        sieve(n as usize) == (0..(n as usize + 1))
+                                .filter(|&i| is_prime(i))
+                                .collect::<Vec<_>>()
     }
-    quickcheck(prop_prime_iff_in_the_sieve as fn(usize) -> bool);
+    quickcheck(prop_prime_iff_in_the_sieve as fn(u8) -> bool);
 }
 
 #[test]


### PR DESCRIPTION
This is supposed to address both #119 and #190 by interpreting the generator's size parameter as a bias towards the induced range, instead of as a hard limit. Specifically:

  * Values within the range induced by the size parameter occur with >  0.5 probability (currently ~.75 but it needn't be exposed to such a granularity on the API, so as to allow easy modifications / refinement).
  * Values outside of the induced range occur with < 0.5 probability.
  * Special values like 0, min_value and max_value generally occur  more frequently than any other value.

In accordance with intuition, lowering the size parameter increases the probability of smaller numbers and increasing the size parameter increases the probability of larger numbers being generated.

The distribution could be further refined but I was trying to keep it simple while solving the main problem of sampling from the entire range such that the influence of the generator's `size` is easily described and understood. [Here are some sample distributions with size=100](https://gist.github.com/romanb/ca0144b88e63cb79661ad64076004fc6) (the default size).

Further comments:

  1. Because I expanded the tests a little and also wanted to cover `i128` / `u128`, I bumped the dependencies on `rand` and `rand_core` to `0.6` and `0.3`, respectively, requiring a few minor modifications.
  
  2. Because the latest version of the transitive dependency `lazy_static` has a lower bound for rustc >= 1.24.1 I bumped the lower bound for quickcheck accordingly. If you are willing to go up to `1.26`, the feature gate for `i128` could be removed, as it stabilised in that release. Would that be desirable?

  3. The `assert!`s serve only to state the established invariants and could be removed or turned into comments, if desired.