### PR TITLE
#[derive(Arbitrary)] V3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rust:
   - beta
   - nightly
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
+  - cargo build --all --verbose
+  - cargo test --all --verbose
+  - cargo doc --all
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.22.0
+  - 1.24.1
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,5 @@ script:
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi
-  - if [ "$TRAVIS_RUST_VERSION" != "1.12.0" ]; then
-      cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml;
-      cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml;
-    fi
+  - cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml;
+  - cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,7 @@ script:
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi
-  - cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml
-  - cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml
+  - if [ "$TRAVIS_RUST_VERSION" != "1.12.0" ]; then
+      cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml;
+      cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ rust:
   - beta
   - nightly
 script:
-  - cargo build --all --verbose
-  - cargo test --all --verbose
-  - cargo doc --all
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo doc
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi
+  - cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml
+  - cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck"
-version = "0.6.1"  #:version
+version = "0.6.2"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Automatic property based testing with shrinking."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[workspace]
+members = [
+	"quickcheck_derive"
+]
+
 [package]
 name = "quickcheck"
 version = "0.6.2"  #:version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Unlicense/MIT"
 exclude = ["/.travis.yml", "/Makefile", "/ctags.rust", "/session.vim"]
 
 [workspace]
-members = ["quickcheck_macros"]
+members = ["quickcheck_macros", "quickcheck_derive"]
 
 [features]
 default = ["regex", "use_logging"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
-[workspace]
-members = [
-	"quickcheck_derive"
-]
-
 [package]
 name = "quickcheck"
 version = "0.6.2"  #:version

--- a/quickcheck_derive/.gitignore
+++ b/quickcheck_derive/.gitignore
@@ -1,0 +1,3 @@
+target/
+**/*.rs.bk
+Cargo.lock

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = ["Nathaniel Ringo <remexre@gmail.com>"]
+description = "#[derive(Arbitrary, Clone)]"
+license = "MIT"
+name = "quickcheck_derive"
+version = "0.1.2"
+
+[dependencies]
+quote = "^0.3.15"
+syn = "^0.11.11"
+
+[dev-dependencies.quickcheck]
+path = ".."
+version = "0.4.2"
+
+[lib]
+proc-macro = true

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -11,7 +11,7 @@ syn = "^0.11.11"
 
 [dev-dependencies.quickcheck]
 path = ".."
-version = "0.4.2"
+version = "0.6"
 
 [lib]
 proc-macro = true

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.2"
 [dependencies]
 quote = "^0.3.15"
 syn = "^0.11.11"
+rand = "0.5"
 
 [dev-dependencies.quickcheck]
 path = ".."

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -12,7 +12,7 @@ rand = "0.5"
 
 [dev-dependencies.quickcheck]
 path = ".."
-version = "0.7.2"
+version = "0.8.0"
 
 [lib]
 proc-macro = true

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -11,7 +11,7 @@ syn = "^0.11.11"
 
 [dev-dependencies.quickcheck]
 path = ".."
-version = "0.6"
+version = "0.7.2"
 
 [lib]
 proc-macro = true

--- a/quickcheck_derive/src/attrs.rs
+++ b/quickcheck_derive/src/attrs.rs
@@ -1,0 +1,37 @@
+use quote::Tokens;
+use syn::{Attribute, DeriveInput, Ident, Lit, MetaItem, NestedMetaItem};
+
+pub fn process_attrs(item: &DeriveInput) -> Tokens {
+    let mut toks = quote!(true);
+    for constraint in item.attrs.iter().flat_map(constraints) {
+        toks.append("&&");
+        toks.append("(");
+        toks.append(constraint);
+        toks.append(")");
+    }
+    toks
+}
+
+fn constraints(attr: &Attribute) -> Vec<&str> {
+    match attr.value {
+        MetaItem::List(ref name, ref nested) => if name == &Ident::new("arbitrary") {
+            nested.iter().filter_map(|n| match *n {
+                NestedMetaItem::MetaItem(ref m) => match *m {
+                    MetaItem::NameValue(ref name, ref val) => if name == &Ident::new("constraint") {
+                        match *val {
+                            Lit::Str(ref s, _) => Some(s as &str),
+                            _ => panic!("Invalid 'arbitrary' attribute"),
+                        }
+                    } else {
+                        panic!("Invalid 'arbitrary' attribute");
+                    },
+                    _ => panic!("Invalid 'arbitrary' attribute"),
+                },
+                _ => panic!("Invalid 'arbitrary' attribute"),
+            }).collect()
+        } else {
+            Vec::new()
+        },
+        _ => Vec::new(),
+    }
+}

--- a/quickcheck_derive/src/lib.rs
+++ b/quickcheck_derive/src/lib.rs
@@ -30,13 +30,20 @@ pub fn derive(input: TokenStream) -> TokenStream {
         impl ::quickcheck::Arbitrary for #impl_generics #name #ty_generics #where_clause {
             #[allow(unused_mut, unused_variables)]
             fn arbitrary<G: ::quickcheck::Gen>(_g: &mut G) -> Self {
-                // TODO Find a way to use "self" instead of "this".
-                let valid = |this: &Self| { #valid };
+                trait Valid {
+                    fn valid(&self) -> bool;
+                }
+                impl Valid for #impl_generics #name #ty_generics #where_clause {
+                    fn valid(&self) -> bool {
+                        #valid
+                    }
+                }
+                
                 let mut gen = move || { #arbitrary };
 
                 loop {
                     let out = gen();
-                    if valid(&out) {
+                    if out.valid() {
                         return out;
                     }
                 }

--- a/quickcheck_derive/src/lib.rs
+++ b/quickcheck_derive/src/lib.rs
@@ -1,0 +1,53 @@
+#![crate_type = "proc-macro"]
+#![recursion_limit = "128"]
+
+extern crate proc_macro;
+#[macro_use]
+extern crate quote;
+extern crate syn;
+
+mod attrs;
+mod structural;
+
+use attrs::*;
+use proc_macro::TokenStream;
+use structural::*;
+use syn::{Body, parse_derive_input};
+
+#[proc_macro_derive(Arbitrary, attributes(arbitrary))]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let item = parse_derive_input(&input.to_string())
+        .expect("Couldn't parse item");
+    let (arbitrary, shrink) = match item.body {
+        Body::Struct(ref variant) => derive_struct(&item, &variant),
+        Body::Enum(ref variants) => derive_enum(&item, &variants),
+    };
+    let valid = process_attrs(&item);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+    let ast = quote! {
+        impl ::quickcheck::Arbitrary for #impl_generics #name #ty_generics #where_clause {
+            #[allow(unused_mut, unused_variables)]
+            fn arbitrary<G: ::quickcheck::Gen>(_g: &mut G) -> Self {
+                // TODO Find a way to use "self" instead of "this".
+                let valid = |this: &Self| { #valid };
+                let mut gen = move || { #arbitrary };
+
+                loop {
+                    let out = gen();
+                    if valid(&out) {
+                        return out;
+                    }
+                }
+            }
+
+            fn shrink(&self) -> Box<Iterator<Item=Self>> {
+                #shrink
+            }
+        }
+    };
+    ast.to_string()
+       .parse()
+       .expect("Couldn't parse string to tokens")
+}

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -1,0 +1,170 @@
+use quote::Tokens;
+use syn::{DeriveInput, Field, Ident, Variant, VariantData};
+
+pub fn derive_struct(item: &DeriveInput, variant: &VariantData) -> (Tokens, Tokens) {
+    let name = &item.ident;
+    
+    let arbitrary = arbitrary_variant(variant, name);
+    let shrink = match *variant {
+        VariantData::Struct(ref fields) => {
+            let field_names = fields.iter()
+                .map(|f| f.ident.as_ref().unwrap())
+                .collect::<Vec<_>>();
+            let field_names = &field_names;
+            let alphas = alpha_names(fields.len());
+            let alphas = &alphas;
+
+            let tuple_pattern = match alphas.len() {
+                0 => quote!(()),
+                1 => {
+                    let alpha = &alphas[0];
+                    quote!(#alpha)
+                },
+                _ => quote!((#(#alphas),*)),
+            };
+
+            quote! {
+                Box::new(
+                    (#(self.#field_names),*).shrink().map(|#tuple_pattern| #name {
+                        #(#field_names: #alphas),*
+                    })
+                )
+            }
+        },
+        VariantData::Tuple(ref fields) => {
+            let field_names = (0..fields.len()).map(Ident::new).map(|i| quote!(self.#i));
+            let alpha_names = &alpha_names(fields.len());
+
+            quote! {
+                // TODO This isn't a *great* way to do this until we get
+                // generics over tuples, to be able to implement shrinking
+                // for tuples of all sizes.
+                Box::new((#(#field_names),*).shrink().map(|(#(#alpha_names),*)| #name(#(#alpha_names),*)))
+            }
+        },
+        VariantData::Unit => quote!(quickcheck::empty_shrinker()),
+    };
+
+    (arbitrary, shrink)
+}
+
+pub fn derive_enum(item: &DeriveInput, variants: &[Variant]) -> (Tokens, Tokens) {
+    let name = &item.ident;
+    let variant_count = variants.len();
+    if variants.len() == 0 {
+        panic!("Can't derive Arbitrary on an uninhabited type!");
+    }
+
+    let arbitrary_variants = variants.iter().enumerate().map(|(i, v)| {
+        let arb = arbitrary_variant(&v.data, &v.ident);
+        quote!(#i => #name::#arb)
+    });
+    let shrink_variants = variants.iter().map(|v| enum_shrink_variant(name, v));
+
+    let arbitrary = quote! {
+        match _g.gen_range(0, #variant_count) {
+            #(#arbitrary_variants,)*
+            _ => unreachable!(),
+        }
+    };
+    let shrink = quote! {
+        match *self {
+            #(#shrink_variants,)*
+        }
+    };
+
+    (arbitrary, shrink)
+}
+fn arbitrary_variant(variant: &VariantData, name: &Ident) -> Tokens {
+    match *variant {
+        VariantData::Struct(ref fields) => {
+            let fields = fields.iter().map(derive_field);
+            
+            quote! {
+                #name {
+                    #(#fields),*
+                }
+            }
+        },
+        VariantData::Tuple(ref fields) => {
+            let arbitraries = fields.iter().map(derive_field);
+ 
+            quote! {
+                #name (#(#arbitraries),*)
+            }
+        },
+        VariantData::Unit => quote!(#name),
+    }
+}
+
+fn derive_field(field: &Field) -> Tokens {
+    let gen = quote! { ::quickcheck::Arbitrary::arbitrary(_g) };
+    if let Some(ref name) = field.ident {
+        quote! { #name: #gen }
+    } else {
+        quote! { #gen }
+    }
+}
+
+fn alpha_name(n: usize) -> Ident {
+    Ident::new(format!("quickcheck_derived_param_{}", n))
+}
+fn alpha_names(i: usize) -> Vec<Ident> {
+    (0..i).map(alpha_name).collect()
+}
+
+fn enum_shrink_variant(name: &Ident, v: &Variant) -> Tokens {
+    let ident = &v.ident;
+    match v.data {
+        VariantData::Struct(ref fields) => {
+            let field_names = fields.iter()
+                .map(|f| f.ident.as_ref().unwrap())
+                .collect::<Vec<_>>();
+            let field_names = &field_names;
+            let alphas = alpha_names(fields.len());
+            let alphas = &alphas;
+
+            let tuple_pattern = match alphas.len() {
+                0 => quote!(()),
+                1 => {
+                    let alpha = &alphas[0];
+                    quote!(#alpha)
+                },
+                _ => quote!((#(#alphas),*)),
+            };
+
+            quote! {
+                #name::#ident {
+                    #(#field_names: ref #alphas),*
+                } => {
+                    let iter = (#(#alphas.clone()),*).shrink().map(|#tuple_pattern| #name::#ident {
+                        #(#field_names: #alphas),*
+                    });
+                    Box::new(iter)
+                }
+            }
+        },
+        VariantData::Tuple(ref fields) => {
+            let l = fields.len();
+            let alphas = alpha_names(l);
+            let alphas = &alphas;
+            let tuple_pattern = match alphas.len() {
+                0 => quote!(()),
+                1 => {
+                    let alpha = &alphas[0];
+                    quote!(#alpha)
+                },
+                _ => quote!((#(#alphas),*)),
+            };
+            quote! {
+                #name::#ident(#(ref #alphas),*) => {
+                    let iter = (#(#alphas.clone()),*)
+                        .shrink()
+                        .map(|#tuple_pattern| #name::#ident(#(#alphas),*));
+                    Box::new(iter)
+                }
+            }
+        },
+        VariantData::Unit => quote!(#name::#ident => ::quickcheck::empty_shrinker()),
+    }
+}

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -21,7 +21,10 @@ pub fn derive_struct(item: &DeriveInput, variant: &VariantData) -> (Tokens, Toke
                     (quote!((#(self.#field_names),*)), quote!(#alpha))
                 },
                 length if length > 8 => {
-                    (quote!(tuplify!(#(self.#field_names),*)), quote!(tuplify!(#(#alphas),*)))
+                    (
+                        quote!(tuplify!(#(self.#field_names),*)),
+                        quote!(tuplify_pattern!(#(#alphas),*))
+                    )
                 },
                 _ => (quote!((#(self.#field_names),*)), quote!((#(#alphas),*))),
             };

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -20,6 +20,18 @@ pub fn derive_struct(item: &DeriveInput, variant: &VariantData) -> (Tokens, Toke
                     let alpha = &alphas[0];
                     quote!(#alpha)
                 },
+                length if length > 8 => {
+                    let mut iter = alphas.chunks(8);
+                    let chunk = iter.next().unwrap();
+                    let mut q = quote!((#(#chunk),*));
+                    loop {
+                        match iter.next() {
+                            Some ([single]) => q = quote!((#single, #(#q))),
+                            Some (chunk) => q = quote!((#(#chunk),*) #(#q)),
+                            None => break q,
+                        }
+                    }
+                },
                 _ => quote!((#(#alphas),*)),
             };
 

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -82,7 +82,8 @@ pub fn derive_enum(item: &DeriveInput, variants: &[Variant]) -> (Tokens, Tokens)
     let shrink_variants = variants.iter().map(|v| enum_shrink_variant(name, v));
 
     let arbitrary = quote! {
-        match _g.gen_range(0, #variant_count) {
+        extern crate rand;
+        match rand::Rng::gen_range(_g, 0, #variant_count) {
             #(#arbitrary_variants,)*
             _ => unreachable!(),
         }

--- a/quickcheck_derive/tests/constraints.rs
+++ b/quickcheck_derive/tests/constraints.rs
@@ -4,7 +4,7 @@ extern crate quickcheck;
 extern crate quickcheck_derive;
 
 #[derive(Arbitrary, Clone, Debug)]
-#[arbitrary(constraint = "this.alpha == this.bravo.is_positive()")]
+#[arbitrary(constraint = "self.alpha == self.bravo.is_positive()")]
 struct TestStruct {
     alpha: bool,
     bravo: isize,

--- a/quickcheck_derive/tests/constraints.rs
+++ b/quickcheck_derive/tests/constraints.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+#[arbitrary(constraint = "this.alpha == this.bravo.is_positive()")]
+struct TestStruct {
+    alpha: bool,
+    bravo: isize,
+}
+
+quickcheck! {
+    fn struct_constraint(t: TestStruct) -> bool {
+        t.alpha == t.bravo.is_positive()
+    }
+}

--- a/quickcheck_derive/tests/enum.rs
+++ b/quickcheck_derive/tests/enum.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+enum Xyzzy {
+    Alpha,
+    Bravo(char),
+    Charlie(Vec<char>, Vec<u8>),
+    Delta(Option<char>),
+    Echo(()),
+    Foxtrot {
+        one: bool,
+        two: (),
+        three: isize,
+    },
+    Golf {},
+    Hotel {
+        foo: usize,
+    },
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_xyzzy(_xyzzy: Xyzzy) -> bool {
+        true
+    }
+}

--- a/quickcheck_derive/tests/rect.rs
+++ b/quickcheck_derive/tests/rect.rs
@@ -4,8 +4,8 @@ extern crate quickcheck;
 extern crate quickcheck_derive;
 
 #[derive(Arbitrary, Clone, Debug)]
-#[arbitrary(constraint = "this.left.checked_add(this.width).is_some()")]
-#[arbitrary(constraint = "this.top.checked_add(this.height).is_some()")]
+#[arbitrary(constraint = "self.left.checked_add(self.width).is_some()")]
+#[arbitrary(constraint = "self.top.checked_add(self.height).is_some()")]
 pub struct Rect {
     left: u8,
     top: u8,

--- a/quickcheck_derive/tests/rect.rs
+++ b/quickcheck_derive/tests/rect.rs
@@ -1,0 +1,39 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+#[arbitrary(constraint = "this.left.checked_add(this.width).is_some()")]
+#[arbitrary(constraint = "this.top.checked_add(this.height).is_some()")]
+pub struct Rect {
+    left: u8,
+    top: u8,
+    width: u8,
+    height: u8,
+}
+
+impl Rect {
+    /// Returns the area of the rectangle, or None if it overflows a u8.
+    pub fn area(&self) -> Option<u8> {
+        self.width.checked_mul(self.height)
+    }
+}
+
+quickcheck! {
+    fn zero_area_iff_zero_dim(r: Rect) -> bool {
+        (r.area() == Some(0)) == (r.height == 0 || r.width == 0)
+    }
+}
+
+quickcheck! {
+    fn first_constraint_holds(r: Rect) -> bool {
+        r.left.checked_add(r.width).is_some()
+    }
+}
+
+quickcheck! {
+    fn second_constraint_holds(r: Rect) -> bool {
+        r.top.checked_add(r.height).is_some()
+    }
+}

--- a/quickcheck_derive/tests/struct.rs
+++ b/quickcheck_derive/tests/struct.rs
@@ -21,6 +21,20 @@ struct Quux;
 #[derive(Arbitrary, Clone, Debug)]
 struct Far(i32);
 
+
+#[derive(Arbitrary, Clone, Debug)]
+struct ReallyBigStruct {
+    alpha: i32,
+    bravo: isize,
+    charlie: usize,
+    delta: u32,
+    echo: i8,
+    foxtrot: u8,
+    golf: isize,
+    hotel: usize,
+    india: i32
+}
+
 quickcheck! {
     fn ensure_arbitrary_is_impld_for_foo(_foo: Foo) -> bool {
         true
@@ -47,6 +61,12 @@ quickcheck! {
 
 quickcheck! {
     fn ensure_arbitrary_is_impld_for_far(_far: Far) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_really_big_struct(_really_big_struct: ReallyBigStruct) -> bool {
         true
     }
 }

--- a/quickcheck_derive/tests/struct.rs
+++ b/quickcheck_derive/tests/struct.rs
@@ -1,0 +1,43 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Foo {
+    alpha: i32,
+    bravo: isize,
+}
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Bar(bool, u32, char);
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Baz();
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Quux;
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_foo(_foo: Foo) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_bar(_bar: Bar) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_baz(_baz: Baz) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_quux(_quux: Quux) -> bool {
+        true
+    }
+}

--- a/quickcheck_derive/tests/struct.rs
+++ b/quickcheck_derive/tests/struct.rs
@@ -18,6 +18,9 @@ struct Baz();
 #[derive(Arbitrary, Clone, Debug)]
 struct Quux;
 
+#[derive(Arbitrary, Clone, Debug)]
+struct Far(i32);
+
 quickcheck! {
     fn ensure_arbitrary_is_impld_for_foo(_foo: Foo) -> bool {
         true
@@ -38,6 +41,12 @@ quickcheck! {
 
 quickcheck! {
     fn ensure_arbitrary_is_impld_for_quux(_quux: Quux) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn ensure_arbitrary_is_impld_for_far(_far: Far) -> bool {
         true
     }
 }

--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck_macros"
-version = "0.6.1"  #:version
+version = "0.6.2"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "A macro attribute for quickcheck."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -80,6 +80,10 @@ pub fn single_shrinker<A: 'static>(value: A) -> Box<Iterator<Item=A>> {
 /// Aside from shrinking, `Arbitrary` is different from the `std::Rand` trait
 /// in that it uses a `Gen` to control the distribution of random values.
 ///
+/// This trait can be derived with the `quickcheck_derive` crate. In that case,
+/// constraints can be added via attributes, and the `valid` function will be
+/// generated based on them.
+///
 /// As of now, all types that implement `Arbitrary` must also implement
 /// `Clone`. (I'm not sure if this is a permanent restriction.)
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,30 @@ macro_rules! tuplify {
     };
 }
 
+#[macro_export]
+macro_rules! tuplify_pattern {
+    () => {
+        ()
+    };
+
+    ($p:pat) => {
+        $p
+    };
+
+    ($tuple_pattern:pat, $($tail:pat),+) => {
+        ($tuple_pattern, tuplify_pattern!($($tail),+))
+    };
+}
+
 #[test]
 fn tuplifiy_test() {
     assert_eq!((1, (2, (3, 4))), tuplify!(1,2,3,4));
+}
+
+#[test]
+fn tuplify_pattern_test() {
+    let tuplify_pattern!(a, b, c) = tuplify!(1, 2, 3);
+    assert_eq!((a, b, c), (1, 2, 3));
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,34 +84,22 @@ macro_rules! info {
 
 #[macro_export]
 macro_rules! tuplify {
-    (@as_expr $e:expr) => { $e };
-    
-    (@parse { } -> { $($output:tt)* }) => {
-        tuplify!(@as_expr $($output)* )
+    () => {
+        ()
     };
 
-    (@parse { $($tuple_item:expr)*, $($tail:tt)* } -> { }) => {
-        tuplify!(@parse { $($tail)* } -> { $($tuple_item)* })
-    };
-    
-    (@parse { $($tuple_item:expr)*, $($tail:tt)* } -> { $($output:tt)* }) => {
-        tuplify!(@parse { $($tail)* } -> { ($($output)*, $($tuple_item)*) })
+    ($e:expr) => {
+        $e
     };
 
-    (@parse { $($tuple_item:expr)* } -> { $($output:tt)* }) => {
-        tuplify!(@parse { } -> { ($($output)*, $($tuple_item)*) })
+    ($tuple_item:expr, $($tail:expr),+) => {
+        ($tuple_item, tuplify!($($tail),+))
     };
-
-    (@parse { $t:tt $($ts:tt)* } -> { $($output:tt)* }) => {
-        tuplify!(@parse { $($ts)* } -> { $($output)* })
-    };
-
-    ($($tail:tt)*) => (tuplify!(@parse { $($tail)* } -> { }));
 }
 
 #[test]
 fn tuplifiy_test() {
-    assert_eq!(((((1,2),3),4)), tuplify!(1,2,3,4));
+    assert_eq!((1, (2, (3, 4))), tuplify!(1,2,3,4));
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,39 @@ macro_rules! info {
     ($($_ignore:tt)*) => { () };
 }
 
+#[macro_export]
+macro_rules! tuplify {
+    (@as_expr $e:expr) => { $e };
+    
+    (@parse { } -> { $($output:tt)* }) => {
+        tuplify!(@as_expr $($output)* )
+    };
+
+    (@parse { $($tuple_item:expr)*, $($tail:tt)* } -> { }) => {
+        tuplify!(@parse { $($tail)* } -> { $($tuple_item)* })
+    };
+    
+    (@parse { $($tuple_item:expr)*, $($tail:tt)* } -> { $($output:tt)* }) => {
+        tuplify!(@parse { $($tail)* } -> { ($($output)*, $($tuple_item)*) })
+    };
+
+    (@parse { $($tuple_item:expr)* } -> { $($output:tt)* }) => {
+        tuplify!(@parse { } -> { ($($output)*, $($tuple_item)*) })
+    };
+
+    (@parse { $t:tt $($ts:tt)* } -> { $($output:tt)* }) => {
+        tuplify!(@parse { $($ts)* } -> { $($output)* })
+    };
+
+    ($($tail:tt)*) => (tuplify!(@parse { $($tail)* } -> { }));
+}
+
+#[test]
+fn tuplifiy_test() {
+    assert_eq!(((((1,2),3),4)), tuplify!(1,2,3,4));
+}
+
+
 
 mod arbitrary;
 mod tester;


### PR DESCRIPTION
I wanted to fix the last issue in #205 so I could learn how to debug and write Rust macros.

With this fix, I think the `#[derive(Arbitrary)]` feature is complete.