### PR TITLE
Use `$crate::` prefix in `quickcheck!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ macro_rules! quickcheck {
             }
         )*
     } => (
-        quickcheck! {
+        $crate::quickcheck! {
             @as_items
             $(
                 #[test]


### PR DESCRIPTION
This makes possible using the macro as `quickcheck::quickcheck!` without `use quickcheck::quickcheck;` in Rust 2018.