### PR TITLE
Update to rand 0.7 and rand_core 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.30.0
+  - 1.32.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ name = "quickcheck"
 [dependencies]
 env_logger = { version = "0.6.0", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
-rand = "0.6.5"
-rand_core = "0.4.0"
+rand = "0.7"
+rand_core = "0.5"

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -436,10 +436,10 @@ mod test {
     #[test]
     fn different_generator() {
         fn prop(_: i32) -> bool { true }
-        QuickCheck::with_gen(StdGen::new(OsRng::new().unwrap(), 129))
+        QuickCheck::with_gen(StdGen::new(OsRng, 129))
             .quickcheck(prop as fn(i32) -> bool);
         QuickCheck::new()
-            .gen(StdGen::new(OsRng::new().unwrap(), 129))
+            .gen(StdGen::new(OsRng, 129))
             .quickcheck(prop as fn(i32) -> bool);
     }
 }


### PR DESCRIPTION
This requires bumping minimum supported Rust version to 1.32.0 due to [getrandom](https://github.com/rust-random/getrandom) crate.