### PR TITLE
[WIP] stateful property testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ macro_rules! info {
 
 mod arbitrary;
 mod tester;
+mod statem;
 
 #[cfg(test)]
 mod tests;

--- a/src/statem.rs
+++ b/src/statem.rs
@@ -1,0 +1,204 @@
+
+use crate::tester::{Testable, TestResult};
+use crate::arbitrary::{Gen, Arbitrary};
+use std::fmt::{Debug};
+
+pub trait Model: Default + Debug {
+    type Operation: Arbitrary + Clone + Debug;
+
+    /// Generates a next operation given the current state of self.
+    /// Subsequently, this operation will be subject of [Self::pre] check to
+    /// determine, if it's a correct one in context of a current state.
+    fn next<G: Gen>(&self, g: &mut G) -> Option<Self::Operation> { 
+        Some(Self::Operation::arbitrary(g)) 
+    }
+
+    /// A preconditions used to check if generated operation is correct 
+    /// in sense of a current worflow. This function may be executed 
+    /// multiple times in a single run, therefore it's expected to not 
+    /// produce any side effects.
+    fn pre(&self, _: &Self::Operation) -> bool { true }
+
+    /// An actual operation to be run.
+    fn run(&mut self, op: &Self::Operation) -> bool;
+}
+
+pub struct StateMachine<T: Model> {
+    min_ops: usize,
+    max_ops: usize,
+    init: fn() -> T
+}
+
+impl<T: Model> StateMachine<T> {
+
+    /// Creates a new state machine for a specific test scenario. It will
+    /// be able to create a stateful specification model instances of type
+    /// T per each test run. 
+    pub fn from(init: fn() -> T) -> Self {
+        StateMachine {
+            min_ops: 1,
+            max_ops: 100,
+            init
+        }
+    }
+
+    /// Defines a maximum number of operations to be generated in order to
+    /// produce a stateful test scenario for model T.
+    pub fn max_ops(mut self, value: usize) -> Self {
+        self.max_ops = value;
+        self
+    }
+
+    /// Defines a minimal number of operations to be generated in order to
+    /// produce a stateful test scenario for model T.
+    pub fn min_ops(mut self, value: usize) -> Self {
+        self.min_ops = value;
+        self
+    }
+}
+
+impl<T: Default + Model> Default for StateMachine<T> {
+    fn default() -> Self {
+        StateMachine {
+            min_ops: 1,
+            max_ops: 100,
+            init: T::default
+        }
+    }
+}
+
+impl<T: Model + 'static> Testable for StateMachine<T> {
+
+    fn result<G: Gen>(&self, g: &mut G) -> TestResult {
+        let mut state = (self.init)();
+        let op_count = (g.size() % (self.max_ops - self.min_ops)) + self.min_ops;
+        let mut operations = Vec::with_capacity(op_count);
+        let mut i = 0;
+        while i < op_count {
+            i += 1;
+            loop {
+                let op = state.next(g);
+                match op {
+                    Some(ref o) => {
+                        if state.pre(o) {
+                            operations.push(o.clone());
+                            let result = state.run(o);
+                            if !result {
+                                let arguments = operations.clone()
+                                    .into_iter()
+                                    .take(i+1)
+                                    .map(|op| format!("{:?}", op))
+                                    .collect();
+                                let msg = format!("Model failed in state {:?} after executing {} operations", state, i);
+                                return TestResult::error_with_args(msg, arguments);
+                            } else {
+                                break; // break current generation loop
+                            }
+                        }
+                        // if state.pre failed - loop around and regenerate operation
+                    },
+                    // prematurelly finish test eg. because we reached final state
+                    None => return TestResult::passed(), 
+                };
+            }
+        }
+
+        TestResult::passed()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use rand::rngs::OsRng;
+    use crate::statem::{Model, StateMachine};
+    use crate::arbitrary::{Gen, StdGen, Arbitrary};
+    use crate::tester::QuickCheck;
+    use std::fmt::Debug;
+
+    #[derive(Default, Clone, Debug, PartialEq, Eq)]
+    struct Counter(u32);
+
+    impl Counter {
+
+        fn inc(&mut self) -> u32 {
+            /*
+            // intentional bug
+            if self.0 < 3 {
+                self.0 += 1;
+            } else {
+                self.0 += 2; 
+            }*/
+            self.0 += 1;
+            self.0
+        }
+
+        fn dec(&mut self) -> Result<u32, ()> {
+            if self.0 == 0 {
+                Err(())
+            } else {
+                self.0 -= 1;
+                Ok(self.0)
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum CounterOp {
+        Increment,
+        Decrement,
+    }
+
+    impl Arbitrary for CounterOp {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            if g.next_u32() % 2 == 0 {
+                CounterOp::Increment
+            } else {
+                CounterOp::Decrement
+            }
+        }
+    }
+
+    #[derive(Default, Debug)]
+    struct CounterSpec {
+        counter: Counter,
+    }
+
+    impl Model for CounterSpec {
+        type Operation = CounterOp;
+
+        fn next<G: Gen>(&self, g: &mut G) -> Option<Self::Operation> {
+            Some(CounterOp::arbitrary(g))
+        }
+
+        fn pre(&self, op: &Self::Operation) -> bool {
+            match op {
+                CounterOp::Decrement => self.counter.0 > 0,
+                _ => true
+            }
+        }
+
+        fn run(&mut self, op: &Self::Operation) -> bool {
+            match op {
+                CounterOp::Increment => {
+                    let expected = self.counter.0 + 1;
+                    expected == self.counter.inc()
+                },
+                CounterOp::Decrement => {
+                    let expected = self.counter.0 - 1;
+                    Ok(expected) == self.counter.dec()
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_counter() {
+        let spec = StateMachine::from(CounterSpec::default)
+            .min_ops(20)
+            .max_ops(50);
+
+        QuickCheck::with_gen(StdGen::new(OsRng, 129))
+            .quickcheck(spec);
+    }
+}

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -232,6 +232,13 @@ impl TestResult {
         r
     }
 
+    /// Produces a test result that indicates failure from a runtime error.
+    pub fn error_with_args<S: Into<String>>(msg: S, arguments: Vec<String>) -> TestResult {
+        let mut r = TestResult::error(msg);
+        r.arguments = arguments;
+        r
+    }
+
     /// Produces a test result that instructs `quickcheck` to ignore it.
     /// This is useful for restricting the domain of your properties.
     /// When a test is discarded, `quickcheck` will replace it with a
@@ -278,16 +285,28 @@ impl TestResult {
         self.is_failure() && self.err.is_some()
     }
 
+    fn pretty_format(args: &Vec<String>) -> String {
+        let mut fmt = args.join(", ");
+        if fmt.len() > 80 {
+            fmt = String::with_capacity(80);
+            for (i, arg) in args.iter().enumerate() {
+                fmt.push_str("\n");
+                fmt.push_str(format!("\t{}: {}", i, arg).as_str());
+            }
+        }
+        fmt
+    }
+
     fn failed_msg(&self) -> String {
         match self.err {
             None => format!(
                 "[quickcheck] TEST FAILED. Arguments: ({})",
-                self.arguments.join(", ")
+                Self::pretty_format(&self.arguments)
             ),
             Some(ref err) => format!(
                 "[quickcheck] TEST FAILED (runtime error). \
                  Arguments: ({})\nError: {}",
-                self.arguments.join(", "),
+                Self::pretty_format(&self.arguments),
                 err
             ),
         }


### PR DESCRIPTION
This is an initial PR with API for building stateful property-based tests using the `StateMachine<T>`. To bring the issue closer, here are the docs about the same feature implemented in [Erlang](https://propertesting.com/book_stateful_properties.html) and [F#](https://fscheck.github.io/FsCheck/StatefulTestingNew.html).

API so far was extended by two new structures:

- `Model` trait which defines 3 functions:
    - `run` which mutates current model's state given the generated operation
    - `next` which is supposed to produce new operation to be applied
    - `pre` which is supposed to check if a given operation has any sense in a context of a current model's state.
- `StateMachine<T: Model>` which is just a configurable wrapper around model, which implements `Testable` trait.

The minimal case for non-negative counter with `inc`/`dec` functions could look like this:

```rust 
#[derive(Clone, Debug, Default)]
struct Counter(u32);

impl Counter {
  fn inc(&mut self) -> u32 {
    self.0 += 1;
    self.0
  }

  fn dec(&mut self) -> u32 {
    self.0 -= 1; // better not to run below 0
    self.0
  }
}

// define test model

#[derive(Debug, Clone, PartialEq, Eq)]
enum CounterOp {
    Increment,
    Decrement,
}

impl Arbitrary for CounterOp {
    fn arbitrary<G: Gen>(g: &mut G) -> Self {
        if g.next_u32() % 2 == 0 {
            CounterOp::Increment
        } else {
            CounterOp::Decrement
        }
    }
}

#[derive(Default, Debug)]
struct CounterSpec {
    counter: Counter,
}

impl Model for CounterSpec {
    type Operation = CounterOp;

    fn pre(&self, op: &Self::Operation) -> bool {
        match op {
            CounterOp::Decrement => self.counter.0 > 0,
            _ => true // increments are always safe
        }
    }

    fn run(&mut self, op: &Self::Operation) -> bool {
        match op {
            CounterOp::Increment => {
                let expected = self.counter.0 + 1;
                expected == self.counter.inc()
            },
            CounterOp::Decrement => {
                let expected = self.counter.0 - 1;
                expected == self.counter.dec()
            }
        }
    }
}

#[test]
fn test_counter() {
    let spec = StateMachine::from(CounterSpec::default)
        .max_ops(50);
    QuickCheck::with_gen(StdGen::new(OsRng, 129))
        .quickcheck(spec);
}
```

At the moment, this library doesn't try to shrink the sequence of operations in case of failure.