### PR TITLE
Document Gen::size

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -30,6 +30,10 @@ use rand::{self, Rng, RngCore};
 /// A value with type satisfying the `Gen` trait can be constructed with the
 /// `gen` function in this crate.
 pub trait Gen: RngCore {
+    /// Returns the `size` parameter used by this `Gen`, which controls the size
+    /// of random values generated. For example, it specifies the maximum length
+    /// of a randomly generated vector and also will specify the maximum
+    /// magnitude of a randomly generated number.
     fn size(&self) -> usize;
 }
 


### PR DESCRIPTION
`Gen::size()` (really, the `size` parameter) is described in the docs for StdGen and StdThreadGen, but not in the docs for Gen. So, I copied and pasted the description to the docs for Gen.

I considered moving the paragraph to Gen's docs outright and having StdGen & StdThreadGen link to the new location, but I couldn't find a way to link directly to the `size` function (and the point of this PR is to reduce how much users need to hunt around, anyway).

I also considered linking "default size" in QuickCheck::new to the new documentation in Gen::size because it might be unclear what that means, but the house style of the docs seems to recommend not including internal links (maybe waiting for intra-rustdoc links?), so I didn't add any.