### PR TITLE
Implement arbitrary for CString

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ord;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
+use std::ffi::CString;
 use std::hash::BuildHasherDefault;
 use std::path::PathBuf;
 
@@ -283,6 +284,10 @@ quickcheck! {
     fn substitute_hashmap(
         _map: HashMap<u8, u8, BuildHasherDefault<DefaultHasher>>
     ) -> bool {
+        true
+    }
+
+    fn cstring(_p: CString) -> bool {
         true
     }
 }


### PR DESCRIPTION
Closes #165. This implementation builds a `CString` from either a `String` or a `Vec<u8>`. It shrinks using the `VecShrinker`, everywhere making sure no null characters end up in the `CString`.

To prevent using as many allocations, it is built using an iterator, which is then filtered directly. I can change that if it's undesirable.