### PR TITLE
api: remove Send bound from Arbitrary/Testable traits

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -142,11 +142,7 @@ pub fn single_shrinker<A: 'static>(value: A) -> Box<dyn Iterator<Item = A>> {
 ///
 /// As of now, all types that implement `Arbitrary` must also implement
 /// `Clone`. (I'm not sure if this is a permanent restriction.)
-///
-/// They must also be sendable and static since every test is run in its own
-/// thread using `thread::Builder::spawn`, which requires the `Send + 'static`
-/// bounds.
-pub trait Arbitrary: Clone + Send + 'static {
+pub trait Arbitrary: Clone + 'static {
     fn arbitrary<G: Gen>(g: &mut G) -> Self;
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
@@ -401,7 +397,7 @@ impl<K: Arbitrary + Ord, V: Arbitrary> Arbitrary for BTreeMap<K, V> {
 impl<
         K: Arbitrary + Eq + Hash,
         V: Arbitrary,
-        S: BuildHasher + Default + Clone + Send + 'static,
+        S: BuildHasher + Default + Clone + 'static,
     > Arbitrary for HashMap<K, V, S>
 {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
@@ -441,10 +437,8 @@ impl<T: Arbitrary + Ord> Arbitrary for BinaryHeap<T> {
     }
 }
 
-impl<
-        T: Arbitrary + Eq + Hash,
-        S: BuildHasher + Default + Clone + Send + 'static,
-    > Arbitrary for HashSet<T, S>
+impl<T: Arbitrary + Eq + Hash, S: BuildHasher + Default + Clone + 'static>
+    Arbitrary for HashSet<T, S>
 {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let vec: Vec<T> = Arbitrary::arbitrary(g);

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -256,8 +256,8 @@ impl TestResult {
     pub fn must_fail<T, F>(f: F) -> TestResult
     where
         F: FnOnce() -> T,
-        F: Send + 'static,
-        T: Send + 'static,
+        F: 'static,
+        T: 'static,
     {
         let f = panic::AssertUnwindSafe(f);
         TestResult::from_bool(panic::catch_unwind(f).is_err())
@@ -305,7 +305,7 @@ impl TestResult {
 /// and potentially shrink those arguments if they produce a failure.
 ///
 /// It's unlikely that you'll have to implement this trait yourself.
-pub trait Testable: Send + 'static {
+pub trait Testable: 'static {
     fn result<G: Gen>(&self, _: &mut G) -> TestResult;
 }
 
@@ -330,7 +330,7 @@ impl Testable for TestResult {
 impl<A, E> Testable for Result<A, E>
 where
     A: Testable,
-    E: Debug + Send + 'static,
+    E: Debug + 'static,
 {
     fn result<G: Gen>(&self, g: &mut G) -> TestResult {
         match *self {
@@ -409,8 +409,8 @@ testable_fn!(A, B, C, D, E, F, G, H);
 fn safe<T, F>(fun: F) -> Result<T, String>
 where
     F: FnOnce() -> T,
-    F: Send + 'static,
-    T: Send + 'static,
+    F: 'static,
+    T: 'static,
 {
     panic::catch_unwind(panic::AssertUnwindSafe(fun)).map_err(|any_err| {
         // Extract common types of panic payload:


### PR DESCRIPTION
The Send bound is a relic from the past. Indeed, the docs for the
Arbitrary trait have been outdated for quite some time. quickcheck
stopped running each test in a separate thread once
`std::panic::catch_unwind` was stabilized many moons ago. With
`catch_unwind`, the `Send` bound is no longer necessary.

We do need to retain the `'static` bound though. Without that,
implementing shrink seems implausible.

Fixes #262