### PR TITLE
Eliminate panic on overflowing absolute value

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -824,7 +824,9 @@ macro_rules! signed_shrinker {
             impl Iterator for SignedShrinker {
                 type Item = $ty;
                 fn next(&mut self) -> Option<$ty> {
-                    if (self.x - self.i).abs() < self.x.abs() {
+                    if self.x == <$ty>::MIN
+                        || (self.x - self.i).abs() < self.x.abs()
+                    {
                         let result = Some(self.x - self.i);
                         self.i = self.i / 2;
                         result

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -443,7 +443,7 @@ mod test {
     #[test]
     fn regression_signed_shrinker_panic() {
         fn foo_can_shrink(v: i8) -> bool {
-            let _ = crate::Arbitrary::shrink(&v);
+            let _ = crate::Arbitrary::shrink(&v).take(100).count();
             true
         }
         crate::quickcheck(foo_can_shrink as fn(i8) -> bool);


### PR DESCRIPTION
See #268. This ensures that the shrinker does not panic when _using_ the value, not just _constructing_ it.