### PR TITLE
Feature-gated implementation of `rand_core::RngCore` for `quickcheck::Gen`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
     - run: cargo test --verbose
     - run: cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml
     - run: cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml
+    # Make sure that the crate compiles if all features flags are switched on at the same time.
+    - run: cargo check --all-features --verbose
 
   rustfmt:
     name: rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = ["quickcheck_macros"]
 default = ["regex", "use_logging"]
 use_logging = ["log", "env_logger"]
 regex = ["env_logger/regex"]
+use_rand_core_0_6 = ["rand_core_0_6"]
 
 [lib]
 name = "quickcheck"
@@ -28,3 +29,4 @@ name = "quickcheck"
 env_logger = { version = "0.8.2", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 rand = { version = "0.8", default-features = false, features = ["getrandom", "small_rng"] }
+rand_core_0_6 = { package = "rand_core", version = "0.6", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Crate features:
   `RUST_LOG`.
 - `"regex"`: (Enabled by default.) Enables the use of regexes with
   `env_logger`.
-- `"rand_core_0_6"`: (Disabled by default.) Provides an implementation of 
-  `rand_core::RngCore` for `quickcheck::Gen`.
+- `"use_rand_core_0_6"`: (Disabled by default.) Provides an implementation of 
+  `rand_core::RngCore` for `quickcheck::Gen` using version `0.6` of `rand_core`.
 
 
 ### Minimum Rust version policy

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Crate features:
   `RUST_LOG`.
 - `"regex"`: (Enabled by default.) Enables the use of regexes with
   `env_logger`.
+- `"rand_core_0_6"`: (Disabled by default.) Provides an implementation of 
+  `rand_core::RngCore` for `quickcheck::Gen`.
 
 
 ### Minimum Rust version policy
@@ -140,10 +142,9 @@ version of Rust.
 In general, this crate will be conservative with respect to the minimum
 supported version of Rust.
 
-With all of that said, currently, `rand` is a public dependency of
-`quickcheck`. Therefore, the MSRV policy above only applies when it is more
-aggressive than `rand`'s MSRV policy. Otherwise, `quickcheck` will defer to
-`rand`'s MSRV policy.
+If you are opting-in to use the `rand_core_X_X` feature flags, the MSRV policy 
+above only applies when it is more aggressive than `rand`'s MSRV policy. 
+Otherwise, `quickcheck` will defer to `rand`'s MSRV policy.
 
 
 ### Compatibility

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -24,6 +24,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use rand::seq::SliceRandom;
 use rand::{self, Rng, SeedableRng};
 
+mod rand_rng_impl;
+
 /// Gen represents a PRNG.
 ///
 /// It is the source of randomness from which QuickCheck will generate

--- a/src/arbitrary/rand_rng_impl.rs
+++ b/src/arbitrary/rand_rng_impl.rs
@@ -1,0 +1,32 @@
+//! Implement the `RngCore` trait from `rand_core` for `quickcheck::Gen`.
+//! This allows `quickcheck` to interoperate with other crates that rely on `rand_core`/`rand` as
+//! their interface for sources of randomness.
+//!
+//! The `RngCore` implementations are gated behind opt-in feature flags that are explicitly tied to a
+//! pinned version of `rand_core`.
+//! If a new version of `rand_core` is released, `quickcheck` can add a new `use_rand_core_X_X`
+//! feature flag to enable interoperability without compromising its API stability guarantees.
+
+#[cfg(feature = "use_rand_core_0_6")]
+mod rand_core_0_6 {
+    use crate::Gen;
+    use rand::Error;
+
+    impl rand_core_0_6::RngCore for Gen {
+        fn next_u32(&mut self) -> u32 {
+            self.rng.next_u32()
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            self.rng.next_u64()
+        }
+
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            self.rng.fill_bytes(dest)
+        }
+
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+            self.rng.try_fill_bytes(dest)
+        }
+    }
+}


### PR DESCRIPTION
# Rationale

The latest version of `quickcheck`, `1.x.x`, has transformed `Gen` into a struct which does not implement the `rand_core::RngCore` trait.  
Reading through https://github.com/BurntSushi/quickcheck/issues/241 it seems the main motivation is API stability: `rand_core` has been publishing minor releases at a much faster pace than `quickcheck` and the API does not yet seem stable enough to allow `quickcheck` to cut a `1.0` release without having to plan for a `2.0` shortly afterwards.  
The other motivation mentioned in the RFC, dependency bloat, seems to have been archived due to a restructuring in `rand`'s feature flagging system - `rand` is in fact a dependency of `quickcheck` in `1.0`. 

While I appreciate the driver behind the decision the outcome seems to damage interoperability across the ecosystem - with all its issues, `rand_core::RngCore` is still the reference trait for crates that want to allow a pluggable source of randomness (e.g. `fake`).  
I believe there is path forward that allows `quickcheck` to avoid unnecessary breaking changes while enabling users that rely on `rand_core` for interoperability to get a `Gen` struct that implements `RngCore` - the present PR.  
There is no denying that somebody has to pay the bill for `rand_core`'s frequent breaking changes: this PR adds complexity that `quickcheck`'s maintainers will have to look after going forward, therefore I understand if you don't want to merge it @BurntSushi. But I thought it was worth a shot to flesh it out as a PoC for your evaluation 😁 

# Changes

Add an implementation of `rand_core::RngCore` for `Gen` behind an optional (disabled by default) feature flag - `rand_core_0_6`.

The features flags are structured to allow backwards-compatible additions of new `RngCore` implementations if `rand_core` were to cut a new release with breaking changes (either 0.7 or 1.x).