### PR TITLE
Fix build for wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ name = "quickcheck"
 env_logger = { version = "0.8.2", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 rand = { version = "0.8", default-features = false, features = ["getrandom", "small_rng"] }
+
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
Fixes #274 
Explicitly select `getrandom` with the `js` feature when building for `wasm32-unknown-unknown`