### PR TITLE
Exclude i128 and u128 when targeting emscripten

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1351,7 +1351,6 @@ mod test {
         eq(0usize, vec![]);
     }
 
-    #[cfg(not(target_os = "emscripten"))]
     #[test]
     fn uints8() {
         eq(5u8, vec![0, 3, 4]);

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -11,8 +11,10 @@ use std::net::{
 };
 use std::num::Wrapping;
 use std::num::{
-    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
 };
+#[cfg(not(target_os = "emscripten"))]
+use std::num::NonZeroU128;
 use std::ops::{
     Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo,
     RangeToInclusive,
@@ -1189,21 +1191,16 @@ mod test {
     #[test]
     fn arby_int() {
         arby_int!(true, i8, i16, i32, i64, isize);
-    }
 
-    #[cfg(not(target_os = "emscripten"))]
-    #[test]
-    fn arby_int_128() {
+        #[cfg(not(target_os = "emscripten"))]
         arby_int!(true, i128);
     }
 
     #[test]
     fn arby_uint() {
         arby_int!(false, u8, u16, u32, u64, usize);
-    }
 
-    #[cfg(not(target_os = "emscripten"))]
-    fn arby_uint_128() {
+        #[cfg(not(target_os = "emscripten"))]
         arby_int!(false, u128);
     }
 

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -795,7 +795,12 @@ macro_rules! unsigned_arbitrary {
 }
 
 unsigned_arbitrary! {
-    usize, u8, u16, u32, u64, u128
+    usize, u8, u16, u32, u64
+}
+
+#[cfg(not(target_os = "emscripten"))]
+unsigned_arbitrary! {
+    u128
 }
 
 macro_rules! signed_shrinker {
@@ -867,7 +872,12 @@ macro_rules! signed_arbitrary {
 }
 
 signed_arbitrary! {
-    isize, i8, i16, i32, i64, i128
+    isize, i8, i16, i32, i64
+}
+
+#[cfg(not(target_os = "emscripten"))]
+signed_arbitrary! {
+     i128
 }
 
 macro_rules! float_problem_values {
@@ -973,7 +983,11 @@ unsigned_non_zero_arbitrary! {
     NonZeroU8    => u8,
     NonZeroU16   => u16,
     NonZeroU32   => u32,
-    NonZeroU64   => u64,
+    NonZeroU64   => u64
+}
+
+#[cfg(not(target_os = "emscripten"))]
+unsigned_non_zero_arbitrary! {
     NonZeroU128  => u128
 }
 
@@ -1174,12 +1188,23 @@ mod test {
 
     #[test]
     fn arby_int() {
-        arby_int!(true, i8, i16, i32, i64, isize, i128);
+        arby_int!(true, i8, i16, i32, i64, isize);
+    }
+
+    #[cfg(not(target_os = "emscripten"))]
+    #[test]
+    fn arby_int_128() {
+        arby_int!(true, i128);
     }
 
     #[test]
     fn arby_uint() {
-        arby_int!(false, u8, u16, u32, u64, usize, u128);
+        arby_int!(false, u8, u16, u32, u64, usize);
+    }
+
+    #[cfg(not(target_os = "emscripten"))]
+    fn arby_uint_128() {
+        arby_int!(false, u128);
     }
 
     macro_rules! arby_float {
@@ -1315,6 +1340,7 @@ mod test {
         eq(0i64, vec![]);
     }
 
+    #[cfg(not(target_os = "emscripten"))]
     #[test]
     fn ints128() {
         eq(5i128, vec![0, 3, 4]);
@@ -1328,6 +1354,7 @@ mod test {
         eq(0usize, vec![]);
     }
 
+    #[cfg(not(target_os = "emscripten"))]
     #[test]
     fn uints8() {
         eq(5u8, vec![0, 3, 4]);
@@ -1352,6 +1379,7 @@ mod test {
         eq(0u64, vec![]);
     }
 
+    #[cfg(not(target_os = "emscripten"))]
     #[test]
     fn uints128() {
         eq(5u128, vec![0, 3, 4]);


### PR DESCRIPTION
Fixes #272 
The `i128` and `u128` experimental types are not well supported by emscripten, and `rand` doesn't support them when targeting emscripten.
This PR excludes supports for `i128` and `u128` from quickcheck to properly build when targeting emscripten.

(In the future we might encounter other build targets that don't support `i128` and `i128`, and we should be able to exclude from them with little adjustments)

Not included in this PR:
- Ensuring that building for emscripten succeeds in CI (I am not familiar with the GitHub CI YAML :-( ) 