### PR TITLE
Shut up non_fmt_panic warning

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1365,11 +1365,11 @@ mod test {
                 for n in v {
                     let found = shrunk.iter().any(|&i| i == n);
                     if !found {
-                        panic!(format!(
+                        panic!(
                             "Element {:?} was not found \
                              in shrink results {:?}",
                             n, shrunk
-                        ));
+                        );
                     }
                 }
             }

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -162,7 +162,7 @@ impl QuickCheck {
 
         let n_tests_passed = match self.quicktest(f) {
             Ok(n_tests_passed) => n_tests_passed,
-            Err(result) => panic!(result.failed_msg()),
+            Err(result) => panic!("{}", result.failed_msg()),
         };
 
         if n_tests_passed >= self.min_tests_passed {


### PR DESCRIPTION
Like a few other macros, `panic!` accepts a format string and arguments.
The format string is meant to be static and calling it with a message string will generate a warning.
Currently, the warning also indicates that `rustc` will generate an error instead in the near future.