### PR TITLE
Convenience function for generation of recursive structures

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -39,15 +39,33 @@ pub struct Gen {
 }
 
 impl Gen {
-    /// Returns a `Gen` with the given size configuration.
+    pub(crate) const DEFAULT_SIZE: usize = 100;
+
+    /// Returns a `Gen` with a random seed and the given size configuration.
+    pub fn new(size: usize) -> Gen {
+        Gen { rng: rand::rngs::SmallRng::from_entropy(), size: size }
+    }
+
+    /// Returns a `Gen` with the given seed and a default size configuration.
+    ///
+    /// Two `Gen`s created with the same seed will generate the same values. Though the values
+    /// may vary between QuickCheck releases.
+    pub fn from_seed(seed: u64) -> Gen {
+        Gen {
+            rng: rand::rngs::SmallRng::seed_from_u64(seed),
+            size: Self::DEFAULT_SIZE,
+        }
+    }
+
+    /// Sets the size configuration for this generator.
     ///
     /// The `size` parameter controls the size of random values generated.
     /// For example, it specifies the maximum length of a randomly generated
     /// vector, but is and should not be used to control the range of a
     /// randomly generated number. (Unless that number is used to control the
     /// size of a data structure.)
-    pub fn new(size: usize) -> Gen {
-        Gen { rng: rand::rngs::SmallRng::from_entropy(), size: size }
+    pub fn set_size(&mut self, size: usize) {
+        self.size = size;
     }
 
     /// Returns the size configured with this generator.

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -80,6 +80,17 @@ impl Gen {
         slice.choose(&mut self.rng)
     }
 
+    /// Creates a generator suitable for recursion.
+    ///
+    /// The returned generator's size will be the origianl gnerator's size
+    /// divided by n. In addition, the new generator will be seeded from the
+    /// original.
+    pub fn sub(&mut self, num: NonZeroUsize) -> Self {
+        let mut res = Self::from_seed(self.gen());
+        res.set_size(self.size() / num);
+        res
+    }
+
     fn gen<T>(&mut self) -> T
     where
         rand::distributions::Standard: rand::distributions::Distribution<T>,

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -33,7 +33,7 @@ fn qc_max_tests() -> u64 {
 }
 
 fn qc_gen_size() -> usize {
-    let default = 100;
+    let default = Gen::DEFAULT_SIZE;
     match env::var("QUICKCHECK_GENERATOR_SIZE") {
         Ok(val) => val.parse().unwrap_or(default),
         Err(_) => default,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -255,6 +255,12 @@ fn all_tests_discarded_min_tests_passed_missing() {
 }
 
 quickcheck! {
+    /// The documentation on `Gen::sub_n` adversizes some easy-to-check property
+    /// regarding the generators' sizes.
+    fn gen_sub_size_sum(original: usize, num: std::num::NonZeroUsize) -> bool {
+        Gen::new(original).sub(num).size() * num.get() <= original
+    }
+
     /// The following is a very simplistic test, which only verifies
     /// that our PathBuf::arbitrary does not panic.  Still, that's
     /// something!  :)


### PR DESCRIPTION
When generating recursive structures, users will often use the size of the generator to bound the recursion depth. Dividing the size by the number of sub-structures appears to be a common practice. However, modifying the size of the generator passed to an implementation of `Arbitrary::arbitrary` would also affect the generation of sister structures if not restored after the generation of child nodes. Instead, users may choose to create a new generator instance with the target size.

The new function makes use of seed from the original generator rather than entropy. In addition to bounding recursive structures, this also allows to re-create those structures based on some initial seed.

This PR is based on #278 (in order to make use of `from_seed`).