### PR TITLE
WIP: Enable generator to be seeded via the environment

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -39,15 +39,33 @@ pub struct Gen {
 }
 
 impl Gen {
-    /// Returns a `Gen` with the given size configuration.
+    pub(crate) const DEFAULT_SIZE: usize = 100;
+
+    /// Returns a `Gen` with a random seed and the given size configuration.
+    pub fn new(size: usize) -> Gen {
+        Gen { rng: rand::rngs::SmallRng::from_entropy(), size: size }
+    }
+
+    /// Returns a `Gen` with the given seed and a default size configuration.
+    ///
+    /// Two `Gen`s created with the same seed will generate the same values. Though the values
+    /// may vary between QuickCheck releases.
+    pub fn from_seed(seed: u64) -> Gen {
+        Gen {
+            rng: rand::rngs::SmallRng::seed_from_u64(seed),
+            size: Self::DEFAULT_SIZE,
+        }
+    }
+
+    /// Sets the size configuration for this generator.
     ///
     /// The `size` parameter controls the size of random values generated.
     /// For example, it specifies the maximum length of a randomly generated
     /// vector, but is and should not be used to control the range of a
     /// randomly generated number. (Unless that number is used to control the
     /// size of a data structure.)
-    pub fn new(size: usize) -> Gen {
-        Gen { rng: rand::rngs::SmallRng::from_entropy(), size: size }
+    pub fn set_size(&mut self, size: usize) {
+        self.size = size;
     }
 
     /// Returns the size configured with this generator.

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -33,7 +33,7 @@ fn qc_max_tests() -> u64 {
 }
 
 fn qc_gen_size() -> usize {
-    let default = 100;
+    let default = Gen::DEFAULT_SIZE;
     match env::var("QUICKCHECK_GENERATOR_SIZE") {
         Ok(val) => val.parse().unwrap_or(default),
         Err(_) => default,

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -40,6 +40,10 @@ fn qc_gen_size() -> usize {
     }
 }
 
+fn qc_seed() -> Option<u64> {
+    env::var("QUICKCHECK_SEED").ok().and_then(|v| v.parse().ok())
+}
+
 fn qc_min_tests_passed() -> u64 {
     let default = 0;
     match env::var("QUICKCHECK_MIN_TESTS_PASSED") {
@@ -59,7 +63,13 @@ impl QuickCheck {
     /// number of overall tests is set to `10000` and the generator is created
     /// with a size of `100`.
     pub fn new() -> QuickCheck {
-        let gen = Gen::new(qc_gen_size());
+        let gen = if let Some(seed) = qc_seed() {
+            let mut g = Gen::from_seed(seed);
+            g.set_size(qc_gen_size());
+            g
+        } else {
+            Gen::new(qc_gen_size())
+        };
         let tests = qc_tests();
         let max_tests = cmp::max(tests, qc_max_tests());
         let min_tests_passed = qc_min_tests_passed();


### PR DESCRIPTION
This change allows generators in a `QuickCheck` instance to be seeded via the environment. The main motivation is faithfully reproducing tests, i.e. with the same seeds. One common use-case would be automated bisects.

For example, a CI system could provide a seed which is stored alongside the report. In the case of failure, that seed could then be used for bisecting, ruling out the chance of falsely flagging a "bad" commit as "good" due to the randomness of input values.

This change is based on #278 (for `Gen::from_seed`).

----

What's still missing:
 * [ ] Documentation: I found the section of the README mentioning the other environment variables not a suitable place.
 * [ ] Decide whether or not it's a problem to use the same seed for all tests. I don't think so, since the same seeded `Gen` will be used for all runs of a given test, and thus we'll produce different input values for each iteration. But maybe I overlooked something?