### PR TITLE
Implement Arbitrary for fixed-sized arrays of Arbitrary elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck"
-version = "1.0.3"  #:version
+version = "1.0.3" #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Automatic property based testing with shrinking."
 documentation = "https://docs.rs/quickcheck"
@@ -28,3 +28,4 @@ name = "quickcheck"
 env_logger = { version = "0.8.2", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 rand = { version = "0.8", default-features = false, features = ["getrandom", "small_rng"] }
+array-init = "2"

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -195,6 +195,12 @@ impl<A: Arbitrary, B: Arbitrary> Arbitrary for Result<A, B> {
     }
 }
 
+impl<T: Arbitrary, const N: usize> Arbitrary for [T; N] {
+    fn arbitrary(g: &mut Gen) -> Self {
+        array_init::array_init(|_| T::arbitrary(g))
+    }
+}
+
 macro_rules! impl_arb_for_single_tuple {
     ($(($type_param:ident, $tuple_index:tt),)*) => {
         impl<$($type_param),*> Arbitrary for ($($type_param,)*)


### PR DESCRIPTION
- [x] Implement `Arbitrary::gen`
- [ ] Implement `Arbitrary::shrink`

I tried implementing a non-trivial shrinker, but this ended up requiring `T: Clone`
and a lot of lifetime issues, so it seemed better to keep the dummy shrinker.

This PR depends on `const` generics, so that would bump the MSRV to 1.51 and
require a minor release.  Alternatively, this functionality could be hidden
behind an opt-in feature flag.
