### PR TITLE
Add a wrapper for disabling shrinking for an Arbitrary

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1124,6 +1124,49 @@ impl Arbitrary for SystemTime {
     }
 }
 
+/// Wrapper for disabling shrinking for an Arbitrary
+///
+/// This type allows generating values via a given `Arbitrary` implementation
+/// for a test for which we don't want to shrink input values.
+///
+/// # Example
+///
+/// ```rust
+/// use quickcheck::{QuickCheck, NoShrink};
+///
+/// fn prop_sane_shrinker() {
+///     // Yielding the original value will result in endless recursion
+///     fn shrinker_no_self(value: NoShrink<u16>) -> bool {
+///         use quickcheck::Arbitrary;
+///         !value.as_ref().shrink().any(|v| v == *value.as_ref())
+///     }
+///     QuickCheck::new().quickcheck(shrinker_no_self as fn(NoShrink<u16>) -> bool);
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct NoShrink<A: Arbitrary>{
+    inner: A,
+}
+
+impl<A: Arbitrary> NoShrink<A> {
+    /// Unwrap the inner value
+    pub fn into_inner(self) -> A {
+        self.inner
+    }
+}
+
+impl<A: Arbitrary> Arbitrary for NoShrink<A> {
+    fn arbitrary(gen: &mut Gen) -> Self {
+        Self{inner: Arbitrary::arbitrary(gen)}
+    }
+}
+
+impl<A: Arbitrary> AsRef<A> for NoShrink<A> {
+    fn as_ref(&self) -> &A {
+        &self.inner
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ new kind of witness being generated. These sorts of changes may happen in
 semver compatible releases.
 */
 
-pub use crate::arbitrary::{empty_shrinker, single_shrinker, Arbitrary, Gen};
+pub use crate::arbitrary::{empty_shrinker, single_shrinker, Arbitrary, NoShrink, Gen};
 pub use crate::tester::{quickcheck, QuickCheck, TestResult, Testable};
 
 /// A macro for writing quickcheck tests.


### PR DESCRIPTION
In some cases, users may want to disable shrinking for a specific test. Consider, for example, some complex recursive data type. Naturally, we'd want values to be shrunk for most tests in order to isolate the specific sub-structure provoking the failure. However, due to the complexity we may end up with a shrinker with a certain complexity in itself. Hence, we may want to test our shrinker. For those specific tests, the very shrinking of input values performed by quickcheck could get in our way or cause failures on its own.

Previously, the only way library users could disable shrinking in such cases was to define a wrapper type (in their own code) which forwarded `Arbitrary::arbitrary` but not `Arbitrary::shrink`. We suspect that the possibility of disabling shrinking for selected tests, such as in cases described above, is not too uncommon. The wrapper pattern is easy to understand and blends in well with quickcheck. Shipping one with the library will suit the described use-cases.

The feature was requested in https://github.com/BurntSushi/quickcheck/issues/285#issuecomment-830269716, the wrapper pattern was suggested as a user-side solution in https://github.com/BurntSushi/quickcheck/issues/285#issuecomment-830281502.