### PR TITLE
Do recursive shrinking without recursive function calls

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -344,7 +344,9 @@ impl<T: Testable,
             self_: fn($($name),*) -> T,
             a: ($($name,)*),
         ) -> Option<TestResult> {
-            for t in a.shrink() {
+            let mut r = Default::default();
+            let mut a = a.shrink();
+            while let Some(t) = a.next() {
                 let ($($name,)*) = t.clone();
                 let mut r_new = safe(move || {self_($($name),*)}).result(g);
                 if r_new.is_failure() {
@@ -353,16 +355,16 @@ impl<T: Testable,
                         r_new.arguments = debug_reprs(&[$($name),*]);
                     }
 
-                    // The shrunk value *does* witness a failure, so keep
-                    // trying to shrink it.
-                    let shrunk = shrink_failure(g, self_, t);
+                    // The shrunk value *does* witness a failure, so remember
+                    // it for now
+                    r = Some(r_new);
 
-                    // If we couldn't witness a failure on any shrunk value,
-                    // then return the failure we already have.
-                    return Some(shrunk.unwrap_or(r_new))
+                    // ... and switch over to that value, i.e. try to shrink
+                    // it further.
+                    a = t.shrink()
                 }
             }
-            None
+            r
         }
 
         let self_ = *self;


### PR DESCRIPTION
We try to shrink values recursively, i.e. when a shrunk value witnesses a failure, we'd shrink that value further. Previously, this recursion would be implemented via actual control flow recursion, i.e. a function calling itself. Since the recursion could not be unrolled by the compiler, this could result in stack overflows in some situations.

Albeit such an overflow would often hint at a faulty shrinker (e.g. a shrinker yielding the original value), the stack overflow could also occur in other situations.

Fixed #285.