### PR TITLE
Make SignedShrinker bounded for <$ty>::MIN

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -824,7 +824,9 @@ macro_rules! signed_shrinker {
             impl Iterator for SignedShrinker {
                 type Item = $ty;
                 fn next(&mut self) -> Option<$ty> {
-                    if self.x == <$ty>::MIN
+                    if self.i == 0 {
+                        None
+                    } else if self.x == <$ty>::MIN
                         || (self.x - self.i).abs() < self.x.abs()
                     {
                         let result = Some(self.x - self.i);


### PR DESCRIPTION
Previously, the `SignedShrinker` was guaranteed to yield a result if initialized with `<$ty>::MIN` (e.g. `i32::MIN` for shrinking `i32` and `f32`). This would result in endless shrinking if a test would happen to fail for these values.

Shrinking signed values is done by halfing a second value `i` and subtracting it from the original `x`. Thus `i` will be equal to `0` at some point. We choose to halt the iteration in this state, i.e. not yield any new values. Yielding `x - 0` would be pointless anyway, since that obviously equals the original value which was the initial witness for the test failure.

----

Closes #295.