### PR TITLE
Implement the From<bool> trait for TestResult

### DIFF
--- a/src/tester.rs
+++ b/src/tester.rs
@@ -186,7 +186,7 @@ pub fn quickcheck<A: Testable>(f: A) {
 /// Describes the status of a single instance of a test.
 ///
 /// All testable things must be capable of producing a `TestResult`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TestResult {
     status: Status,
     arguments: Vec<String>,
@@ -194,7 +194,7 @@ pub struct TestResult {
 }
 
 /// Whether a test has passed, failed or been discarded.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 enum Status {
     Pass,
     Fail,
@@ -278,6 +278,21 @@ impl TestResult {
                 err
             ),
         }
+    }
+}
+
+impl From<bool> for TestResult {
+    /// A shorter way of producing a `TestResult` from a `bool`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use quickcheck::TestResult;
+    /// let result: TestResult = (2 > 1).into();
+    /// assert_eq!(result, TestResult::passed());
+    /// ```
+    fn from(b: bool) -> TestResult {
+        TestResult::from_bool(b)
     }
 }
 


### PR DESCRIPTION
Hi @BurntSushi, thank you for this very nice library!

This PR adds an implementation of `From<bool>` for `TestResult`.
It allows using `TestResult::from(true)` everywhere, and `true.into()` when the `TestResult` type can be inferred from the context, which I believe improves ergonomics in some situations:

```rust
// From the README
fn prop(xs: Vec<isize>) -> TestResult {
    if xs.len() != 1 {
        return TestResult::discard()
    }
    (xs == reverse(&xs)).into() // Instead of `TestResult::from_bool(xs == reverse(&xs))`
}
```