### PR TITLE
Bump env_logger from 0.8 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ regex = ["env_logger/regex"]
 name = "quickcheck"
 
 [dependencies]
-env_logger = { version = "0.8.2", default-features = false, optional = true }
+env_logger = { version = "0.9", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 rand = { version = "0.8", default-features = false, features = ["getrandom", "small_rng"] }


### PR DESCRIPTION
Hi! I'm opening this PR to remove env-logger 0.8 from my cargo tree -- it's being pulled in transitively via this crate.

The only breaking change in 0.9 is "Default message format now prints the target instead of the module" (see their [release notes](https://github.com/env-logger-rs/env_logger/releases)) which seems OK here. I've run `cargo test --all-features` on MacOS, please let me know if there's anything else I can do to test.