### PR TITLE
Add support for arrays powered by const generics without unsafe or libs

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -248,6 +248,26 @@ impl_arb_for_tuples! {
     (H, 7),
 }
 
+impl<const N: usize, A: Arbitrary> Arbitrary for [A; N] {
+    fn arbitrary(g: &mut Gen) -> [A; N] {
+        [(); N].map(|_| A::arbitrary(g))
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = [A; N]>> {
+        let cloned = self.clone();
+        let iter = (0..N).flat_map(move |n| {
+            let cloned = cloned.clone();
+            cloned[n].shrink().map(move |shr_value| {
+                let mut result = cloned.clone();
+                result[n] = shr_value;
+                result
+            })
+        });
+
+        Box::new(iter)
+    }
+}
+
 impl<A: Arbitrary> Arbitrary for Vec<A> {
     fn arbitrary(g: &mut Gen) -> Vec<A> {
         let size = {

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1431,6 +1431,45 @@ mod test {
     }
 
     #[test]
+    fn arrays() {
+        eq([false, false], vec![]);
+        eq([true, false], vec![[false, false]]);
+        eq([true, true], vec![[false, true], [true, false]]);
+
+        eq([false, false, false], vec![]);
+        eq([true, false, false], vec![[false, false, false]]);
+        eq(
+            [true, true, false],
+            vec![[false, true, false], [true, false, false]],
+        );
+
+        eq([false, false, false, false], vec![]);
+        eq([true, false, false, false], vec![[false, false, false, false]]);
+        eq(
+            [true, true, false, false],
+            vec![[false, true, false, false], [true, false, false, false]],
+        );
+
+        eq(
+            {
+                let it: [isize; 0] = [];
+                it
+            },
+            vec![],
+        );
+        eq(
+            {
+                let it: [[isize; 0]; 1] = [[]];
+                it
+            },
+            vec![],
+        );
+        eq([1isize; 1], vec![[0; 1]]);
+        eq([11isize; 1], vec![[0; 1], [6; 1], [9; 1], [10; 1]]);
+        eq([3isize, 5], vec![[0, 5], [2, 5], [3, 0], [3, 3], [3, 4]]);
+    }
+
+    #[test]
     fn vecs() {
         eq(
             {


### PR DESCRIPTION
Closes #187

Alternative to #282 that does not use `unsafe`

This seems to have been a heavily requested feature since 2017 now but the hold back was that implementing array support via macros heavily impacts compile times, is limited to some predefined arbitrary length and bloats the docs with unnecessary clutters. The wait was for const generic stabilization which is finally upon us, so we can utilize that and add array support!

Also lol while I was writing the shrink implementation I was like uff too much cloning there's probably a way to write this better that Sushi will tell me about, then while opening this PR I decided to double check there are no PRs open that already do this, which is when I found #282 and saw the exact same implementation I reached. Now I feel much less bad about the implementation