### PR TITLE
Fix simple example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here's an example that tests a function that reverses a vector:
 extern crate quickcheck;
 
 fn reverse<T: Clone>(xs: &[T]) -> Vec<T> {
-    let mut rev = vec!();
+    let mut rev = vec![];
     for x in xs.iter() {
         rev.insert(0, x.clone())
     }
@@ -45,11 +45,12 @@ fn reverse<T: Clone>(xs: &[T]) -> Vec<T> {
 
 #[cfg(test)]
 mod tests {
-  quickcheck! {
-      fn prop(xs: Vec<u32>) -> bool {
-          xs == reverse(&reverse(&xs))
-      }
-  }
+    use crate::reverse;
+    quickcheck! {
+        fn prop(xs: Vec<u32>) -> bool {
+            xs == reverse(&reverse(&xs))
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
Maybe I'm doing something wrong, but the example didn't compile for me until I added a `use crate::reverse`:

```
PS C:\code\playground> cargo test
   Compiling playground v0.1.0 (C:\code\playground)
  --> src\main.rs:17:19
   |
17 |             xs == reverse(&reverse(&xs))
   |                   ^^^^^^^ not found in this scope
   |
help: consider importing this function
   |
15 |     use crate::reverse;
   |
```

I also ran rustfmt on it; the `vec![]` is a suggestion from it.