### PR TITLE
feat: support arbitrary arrays

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -248,6 +248,12 @@ impl_arb_for_tuples! {
     (H, 7),
 }
 
+impl<const N: usize, A: Arbitrary> Arbitrary for [A; N] {
+    fn arbitrary(g: &mut Gen) -> Self {
+        std::array::from_fn(|_ix| A::arbitrary(g))
+    }
+}
+
 impl<A: Arbitrary> Arbitrary for Vec<A> {
     fn arbitrary(g: &mut Gen) -> Vec<A> {
         let size = {


### PR DESCRIPTION
Uses [`std::array::from_fn`](https://doc.rust-lang.org/stable/std/array/fn.from_fn.html), which was introduced in [Rust 1.63.0](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html#stabilized-apis), ~1 year ago