### PR TITLE
[WIP] Upgrade rand to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ name = "quickcheck"
 [dependencies]
 env_logger = { version = "0.8.2", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
-rand = { version = "0.8", default-features = false, features = ["getrandom", "small_rng"] }
+rand = { version = "0.9", default-features = false, features = ["os_rng", "small_rng"] }

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -162,7 +162,7 @@ impl QuickCheck {
 
         let n_tests_passed = match self.quicktest(f) {
             Ok(n_tests_passed) => n_tests_passed,
-            Err(result) => panic!(result.failed_msg()),
+            Err(result) => panic!("{}", result.failed_msg()),
         };
 
         if n_tests_passed >= self.min_tests_passed {


### PR DESCRIPTION
Rand removed the `Uniform` impls for `usize` and `isize` and instead added [`UniformUsize`](https://docs.rs/rand/latest/rand/distr/uniform/struct.UniformUsize.html) and does not have a generator for `isize`. I've commented those bits out for now since this mucks with the design of the `gen` function quite a bit.