### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools::testing"]
 license = "Unlicense OR MIT"
 exclude = ["/Makefile", "/ctags.rust", "/session.vim"]
 edition = "2021"
+rust-version = "1.71.0"
 
 [workspace]
 members = ["quickcheck_macros"]


### PR DESCRIPTION
Should this be added to quickcheck_macros too?