### PR TITLE
Added TestFailure and TestSuccess

### DIFF
--- a/examples/sieve.rs
+++ b/examples/sieve.rs
@@ -1,4 +1,4 @@
-use quickcheck::quickcheck;
+use quickcheck::{quickcheck, TestFailure};
 
 fn sieve(n: usize) -> Vec<usize> {
     if n <= 1 {
@@ -25,15 +25,31 @@ fn is_prime(n: usize) -> bool {
     n != 0 && n != 1 && (2..).take_while(|i| i * i <= n).all(|i| n % i != 0)
 }
 
+// This function demonstrates how to use `TestFailure` to factor test logic into
+// a function with an ergonomic API. In this case, we want to check that all
+// numbers returned by `sieve` are prime, and we want to return a specific error
+// message indicating which non-prime number was found if the test fails.
+fn check_prime(n: usize) -> Result<(), TestFailure> {
+    if is_prime(n) {
+        Ok(())
+    } else {
+        Err(TestFailure::error(format!("{} is not prime", n)))
+    }
+}
+
 fn main() {
-    fn prop_all_prime(n: usize) -> bool {
-        sieve(n).into_iter().all(is_prime)
+    fn prop_all_prime(n: usize) -> Result<(), TestFailure> {
+        for i in sieve(n) {
+            // Return early in case of failure.
+            check_prime(i)?;
+        }
+        Ok(())
     }
 
     fn prop_prime_iff_in_the_sieve(n: usize) -> bool {
         sieve(n) == (0..=n).filter(|&i| is_prime(i)).collect::<Vec<_>>()
     }
 
-    quickcheck(prop_all_prime as fn(usize) -> bool);
+    quickcheck(prop_all_prime as fn(usize) -> _);
     quickcheck(prop_prime_iff_in_the_sieve as fn(usize) -> bool);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@ semver compatible releases.
 pub use crate::arbitrary::{
     empty_shrinker, single_shrinker, Arbitrary, Gen, NoShrink,
 };
-pub use crate::tester::{quickcheck, QuickCheck, TestResult, Testable};
+pub use crate::tester::{
+    quickcheck, QuickCheck, TestFailure, TestResult, TestSuccess, Testable,
+};
 
 /// A macro for writing quickcheck tests.
 ///

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -257,6 +257,8 @@ impl TestResult {
 
     /// Tests if a "procedure" fails when executed. The test passes only if
     /// `f` generates a task failure during its execution.
+    ///
+    /// See [`TestFailure::must_fail`] for a version of this method that returns a `Result<TestSuccess, TestFailure>`.
     pub fn must_fail<T, F>(f: F) -> TestResult
     where
         F: FnOnce() -> T,
@@ -312,6 +314,82 @@ impl From<bool> for TestResult {
     }
 }
 
+/// An enum indicationg where a test passed or was discarded. For use in
+/// conjunction with [`TestFailure`], as in `Result<TestSuccess, TestFailure>`.
+#[derive(Clone, Debug)]
+pub enum TestSuccess {
+    Passed,
+    Discarded,
+}
+
+impl TestSuccess {
+    /// Produces a test success that indicates the current test has passed.
+    pub fn passed() -> Self {
+        Self::Passed
+    }
+
+    /// Produces a test success that indicates the current test has been
+    /// discarded.
+    pub fn discard() -> Self {
+        Self::Discarded
+    }
+}
+
+impl From<TestSuccess> for TestResult {
+    fn from(success: TestSuccess) -> TestResult {
+        match success {
+            TestSuccess::Passed => TestResult::passed(),
+            TestSuccess::Discarded => TestResult::discard(),
+        }
+    }
+}
+
+/// A type representing a test failure, which can be converted into a
+/// `TestResult`.
+///
+/// The type `Result<(), TestFailure>` implements `Testable`, so you can use it
+/// as the return type of a property, allowing the implementation to use the `?`
+/// operator to indicate failure or discarding of a test.
+#[derive(Clone, Debug)]
+pub struct TestFailure(Option<String>);
+
+impl TestFailure {
+    /// Produces a test failure that indicates the current test has failed.
+    pub fn failed() -> Self {
+        Self(None)
+    }
+
+    /// Produces a test failure that indicates failure from a runtime error.
+    pub fn error<S: Into<String>>(msg: S) -> Self {
+        Self(Some(msg.into()))
+    }
+
+    /// Tests if a "procedure" fails when executed. The test passes only if
+    /// `f` generates a task failure during its execution.
+    pub fn must_fail<T, F>(f: F) -> Result<(), Self>
+    where
+        F: FnOnce() -> T,
+        F: 'static,
+        T: 'static,
+    {
+        let f = panic::AssertUnwindSafe(f);
+        if panic::catch_unwind(f).is_err() {
+            Ok(())
+        } else {
+            Err(TestFailure::error("Expected function to fail with a panic."))
+        }
+    }
+}
+
+impl From<TestFailure> for TestResult {
+    fn from(failure: TestFailure) -> TestResult {
+        match failure.0 {
+            None => TestResult::failed(),
+            Some(err) => TestResult::error(err),
+        }
+    }
+}
+
 /// `Testable` describes types (e.g., a function) whose values can be
 /// tested.
 ///
@@ -342,6 +420,18 @@ impl Testable for () {
 impl Testable for TestResult {
     fn result(&self, _: &mut Gen) -> TestResult {
         self.clone()
+    }
+}
+
+impl Testable for TestSuccess {
+    fn result(&self, _: &mut Gen) -> TestResult {
+        self.clone().into()
+    }
+}
+
+impl Testable for TestFailure {
+    fn result(&self, _: &mut Gen) -> TestResult {
+        self.clone().into()
     }
 }
 
@@ -432,7 +522,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{Gen, QuickCheck};
+    use crate::{Gen, QuickCheck, TestFailure};
 
     #[test]
     fn shrinking_regression_issue_126() {
@@ -461,5 +551,14 @@ mod test {
             true
         }
         crate::quickcheck(foo_can_shrink as fn(i8) -> bool);
+    }
+
+    #[test]
+    fn can_return_early_with_question_mark() {
+        fn inner() -> Result<(), TestFailure> {
+            Err(TestFailure::failed())?;
+            Ok(())
+        }
+        assert!(QuickCheck::new().quicktest(inner as fn() -> _).is_err());
     }
 }


### PR DESCRIPTION
The goal of this PR is to enable using the `?` operator in test code to return errors early. This is useful when the test case is factored into multiple functions. Refer to the changes in seive.rs for a toy example.