### PR TITLE
README: add missing "by" in use_logging bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ witnesses for failures.
 
 Crate features:
 
-- `"use_logging"`: (Enabled by default.) Enables the log messages governed
+- `"use_logging"`: (Enabled by default.) Enables the log messages governed by
   `RUST_LOG`.
 - `"regex"`: (Enabled by default.) Enables the use of regexes with
   `env_logger`.


### PR DESCRIPTION
## Summary
- Fix a missing preposition in the README crate-features section.
- Changes "governed `RUST_LOG`" to "governed by `RUST_LOG`".

## Related issue
N/A (trivial documentation wording fix)

## Guideline alignment
- One focused change in one file.
- No behavior or API changes.

## Validation
- Not run (documentation-only change).
